### PR TITLE
fix: live state events never match (dispatcher uses the legacy object-id)

### DIFF
--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -2218,6 +2218,7 @@ to {
       evtSource.addEventListener("state", function(e) {
         try {
           var d = JSON.parse(e.data);
+          if (d && d.name_id) d.id = d.name_id;
           collectState(d);
           if (rendered) handleLiveEvent(d);
         } catch (_) {

--- a/docs/webserver/src/runtime_state.ts
+++ b/docs/webserver/src/runtime_state.ts
@@ -284,6 +284,12 @@
       evtSource.addEventListener("state", function (e) {
         try {
           var d = JSON.parse(e.data);
+          // Normalise the entity key at ingress. The web server sends name_id
+          // ("domain/Friendly Name" - the shape ENTITY_STATE_MAP and the REST
+          // endpoints use) alongside a legacy id ("domain-object_id"). ESPHome
+          // 2026.8.0 drops name_id and switches id to the name form, so preferring
+          // name_id and otherwise leaving id alone is correct either side of that.
+          if (d && d.name_id) d.id = d.name_id;
           collectState(d);
           if (rendered) handleLiveEvent(d);
         } catch (_) {}

--- a/tests/web_module_tests.js
+++ b/tests/web_module_tests.js
@@ -58,4 +58,12 @@ assert.equal(
 );
 assert.ok(publicApp.includes('image.alt = "Buy Me A Coffee"'), "support button image should have accessible text");
 
+// The web server identifies each entity with name_id ("domain/Friendly Name") plus a
+// legacy id ("domain-object_id"). ENTITY_STATE_MAP and the REST endpoints both use the
+// name form, so live events must be resolved via name_id or nothing ever matches.
+assert.ok(
+  publicApp.includes("d.name_id"),
+  "live state events should be resolved by name_id, not the legacy object-id form"
+);
+
 console.log("web module tests passed");


### PR DESCRIPTION
### Summary

The setup page never applies **any** SSE state event. Each event identifies the entity twice —
`name_id` (`"domain/Friendly Name"`) and `id` (`"domain-object_id"`) — but `ENTITY_STATE_MAP` and
the REST endpoints both use the **name** form, while the dispatcher matches on `d.id`. Those never
match, so `ENTITY_STATE_MAP[id]` is always `undefined` and every `id === "domain/Name"` comparison
is dead. `name_id` appears nowhere in the web sources.

Settings still render because they come from `/espframe/api/v1/configuration`. Everything that only
arrives over SSE is silently dead: `installed_version` / `update_available`, backlight and
brightness, sunrise / sunset, the C6 firmware fields, and every `LIVE_RENDER_STATE_KEYS` re-render.

The visible symptom is the Firmware card showing **"Current version: Dev"** — the empty-value
fallback in `displayVersion()`, not a build type — while `GET /text_sensor/Firmware:%20Version`
returns the real version.

Confirmed on a live device: 73 of 73 state events carry both fields, and `id` never contains `/`.

### Fix

```js
var d = JSON.parse(e.data);
if (d && d.name_id) d.id = d.name_id;
collectState(d);
```

One line where the wire format is parsed, so both consumers (`collectState` and `handleLiveEvent`)
are covered and the dispatch logic is untouched.

### Why prefer a field that 2026.8.0 removes

ESPHome is mid-rename. The identifier format moves from `domain-object_id` to `domain/Name`, and
`name_id` is the temporary carrier that publishes the new format early so frontends can migrate
before `id` flips.

| ESPHome | `id` | `name_id` |
|---|---|---|
| <= 2026.7.x | `text_sensor-firmware__version` | `text_sensor/Firmware: Version` |
| >= 2026.8.0 | `text_sensor/Firmware: Version` | *removed* |

> `// name_id: new format {prefix}/{device?}/{name} - frontend should prefer this`
> `// Remove in 2026.8.0 when id switches to new format permanently`
>
> — `web_server.cpp` (2026.7.4). Confirmed in 2026.8.0b3: no `name_id` remains and `id` is built
> in the new form.

So `d.name_id || d.id` resolves to the name form in both eras, and needs no follow-up when the pin
moves.

### Verified on hardware

Guition ESP32-P4 JC8012P4A1. A/B on the same device, reading the rendered DOM headlessly — stock
was flashed first to confirm the measurement can detect failure.

| | stock v1.12.3 | patched |
|---|---|---|
| Current version | `Dev` | `v1.12.3-uifix2` |
| WiFi firmware | `Unknown / Unknown` | `2.12.9 / 2.12.9 / Up-to-date` |
| Previous firmware | *section absent* | `v1.12.2 v1.12.1 v1.12.0 v1.11.0` |

Live propagation, on a page that was never reloaded: toggling Portrait Pairing on the device
re-rendered it (`toggles on: 7 → 6 → 7`). The web app has no `setInterval` and no polling —
`fetchDeviceSettingsState()` runs only on first render and on firmware reconnect — so SSE is the
only mechanism that can explain it.

### Tests

Regression assertion in `tests/web_module_tests.js`, confirmed to fail on the stock bundle and pass
on the patched one. `check:generated`, `webserver:typecheck` and all four web suites pass.

### Files changed

```
docs/webserver/src/runtime_state.ts   normalise the entity key at SSE ingress
docs/public/webserver/app.js          regenerated (npm run webserver:build)
tests/web_module_tests.js             regression assertion
```
