### PR TITLE
ci: align SERVER canary with scoped workspace cleanup

### DIFF
--- a/.github/workflows/server-runner-migration-canary.yml
+++ b/.github/workflows/server-runner-migration-canary.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test "${RUNNER_CLEANUP_WORKSPACE:-}" = false
+          test "${RUNNER_CLEANUP_WORKSPACE:-}" = true
           test "${RUNNER_CLEANUP_TMP:-}" = true
           test "${RUNNER_CLEANUP_DOCKER:-}" = false
           test -f "${ACTIONS_RUNNER_HOOK_JOB_COMPLETED}"


### PR DESCRIPTION
The deployed runner intentionally enables repository-scoped workspace cleanup. This fixes the canary assertion only; no application or runner deployment changes.