### PR TITLE
Fix slideshow pipeline stalls

### DIFF
--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -408,7 +408,9 @@ script:
                   // Non-active slot updates are best-effort; defer them if network/decoder work
                   // is already active to avoid cascaded cancel/restart churn.
                   if (any_downloading && cmd.slot != id(espframe_core).slideshow().state().active_slot) {
-                    id(delayed_prefetch_chain).execute();
+                    id(espframe_core).slideshow().defer_slot_update_due_to_busy(
+                      cmd.slot, id(espframe_core).slideshow().state().slot_flags,
+                      id(espframe_core).slideshow().state().noncritical_remote_updates_in_flight);
                     break;
                   }
                   bool portrait_screen = id(screen_rotation_select).current_option() == "90" ||
@@ -690,6 +692,41 @@ script:
             id(espframe_core).slideshow().state().portrait_preload_slot, id(espframe_core).slideshow().state().portrait_preload_left_ready, id(espframe_core).slideshow().state().portrait_preload_right_ready,
             id(espframe_core).slideshow().state().companion_target_slot, id(immich_request_state).api_retries, id(espframe_core).slideshow().state().download_retries,
             id(immich_request_state).retry_cooldown_until_ms);
+
+  - id: recover_stalled_slideshow
+    mode: single
+    then:
+      - script.stop: delayed_prefetch_chain
+      - script.stop: deferred_companion_search
+      - script.stop: deferred_fetch_into_slot
+      - script.stop: deferred_rejected_slot_fetch
+      - script.stop: deferred_slot0_image_update
+      - script.stop: deferred_slot1_image_update
+      - script.stop: deferred_slot2_image_update
+      - script.stop: deferred_portrait_left_update
+      - script.stop: deferred_portrait_right_update
+      - script.stop: deferred_preload_left_update
+      - script.stop: deferred_preload_right_update
+      - script.stop: immich_fetch_retry
+      - lambda: |-
+          auto &state = id(espframe_core).slideshow().state();
+          state.diagnostic_reason = "pipeline watchdog timeout";
+          state.last_diagnostic_ms = 0;
+          log_immich_pipeline_diag(state.diagnostic_reason.c_str(), millis(), state.last_diagnostic_ms,
+            state.active_slot, state.target_slot, state.active_slot_displayed, state.slot_flags, state.portrait,
+            state.noncritical_remote_updates_in_flight, state.preload_noncritical_in_flight,
+            state.portrait_preload_slot, state.portrait_preload_left_ready, state.portrait_preload_right_ready,
+            state.companion_target_slot, id(immich_request_state).api_retries, state.download_retries,
+            id(immich_request_state).retry_cooldown_until_ms);
+          id(immich_img_0).abort_download();
+          id(immich_img_1).abort_download();
+          id(immich_img_2).abort_download();
+          id(immich_portrait_left).abort_download();
+          id(immich_portrait_right).abort_download();
+          id(immich_portrait_preload_left).abort_download();
+          id(immich_portrait_preload_right).abort_download();
+          id(espframe_core).slideshow().recover_stalled_pipeline();
+      - script.execute: delayed_prefetch_chain
 
   # Shared handler for any slot's on_error (retry up to MAX_ERROR_RETRIES)
   - id: handle_slot_download_error

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -696,6 +696,18 @@ script:
   - id: recover_stalled_slideshow
     mode: single
     then:
+      # Stop every API worker before clearing target_slot and request flags. Their
+      # late callbacks read shared slideshow state and must not outlive recovery.
+      - script.stop: immich_fetch_memory_into_slot
+      - script.stop: immich_fetch_memory_window_day
+      - script.stop: immich_fetch_memory_asset
+      - script.stop: immich_fetch_metadata_into_slot
+      - script.stop: immich_fetch_album_count
+      - script.stop: immich_fetch_statistics_count
+      - script.stop: immich_fetch_metadata_page_probe
+      - script.stop: immich_fetch_metadata_page
+      - script.stop: immich_fetch_into_slot
+      - script.stop: immich_fetch_portrait_companion
       - script.stop: delayed_prefetch_chain
       - script.stop: deferred_companion_search
       - script.stop: deferred_fetch_into_slot

--- a/components/espframe/slideshow_component.h
+++ b/components/espframe/slideshow_component.h
@@ -92,6 +92,8 @@ struct SlideshowRuntimeState {
   bool active_slot_displayed = false;
   uint32_t last_advance_ms = 0;
   uint32_t last_prefetch_start_ms = 0;
+  uint32_t pipeline_blocked_since_ms = 0;
+  bool pipeline_blocked_tracking = false;
   uint32_t last_short_tap_ms = 0;
   int last_downloaded_slot = -1;
   std::string diagnostic_reason;
@@ -130,6 +132,8 @@ struct SlideshowRuntimeState {
 
 class EspFrameSlideshow {
  public:
+  static constexpr uint32_t PIPELINE_STALL_TIMEOUT_MS = 90000;
+
   SlideshowRuntimeState &state() { return this->state_; }
   const SlideshowRuntimeState &state() const { return this->state_; }
   void reset_state() {
@@ -681,6 +685,52 @@ class EspFrameSlideshow {
     }
     this->emit_command(SLIDESHOW_COMMAND_UPDATE_SLOT_IMAGE, slot);
     return true;
+  }
+
+  void defer_slot_update_due_to_busy(int slot, SlotFlags &flags, int &noncritical_count) {
+    if (slot < 0 || slot > 2) return;
+    clear_noncritical(slot, flags, noncritical_count);
+    clear_slot_fetch_in_flight(slot, flags);
+    this->emit_command(SLIDESHOW_COMMAND_PREFETCH_AFTER_DELAY, slot, 500);
+  }
+
+  bool pipeline_watchdog_timed_out(uint32_t now_ms, bool advance_due, bool blocked) {
+    if (!advance_due || !blocked) {
+      this->state_.pipeline_blocked_since_ms = 0;
+      this->state_.pipeline_blocked_tracking = false;
+      return false;
+    }
+    if (!this->state_.pipeline_blocked_tracking) {
+      this->state_.pipeline_blocked_since_ms = now_ms;
+      this->state_.pipeline_blocked_tracking = true;
+      return false;
+    }
+    return (now_ms - this->state_.pipeline_blocked_since_ms) >= PIPELINE_STALL_TIMEOUT_MS;
+  }
+
+  void recover_stalled_pipeline() {
+    this->commands_.clear();
+    this->state_.fetch_queue.clear();
+    this->state_.slot_flags = SlotFlags{};
+    this->state_.preload_noncritical_in_flight = false;
+    this->state_.noncritical_remote_updates_in_flight = 0;
+    this->state_.portrait = PortraitState{};
+    this->state_.portrait_search_datetime.clear();
+    this->state_.portrait_primary_asset_id.clear();
+    this->state_.companion_target_slot = -1;
+    this->state_.portrait_companion_url.clear();
+    this->state_.portrait_preload_slot = -1;
+    this->state_.portrait_preload_left_ready = false;
+    this->state_.portrait_preload_right_ready = false;
+    this->state_.portrait_search_expanded = false;
+    this->state_.portrait_search_generation++;
+    this->state_.portrait_search_request_generation = 0;
+    this->state_.rejected_fetch_target = -1;
+    this->state_.download_retries = 0;
+    this->state_.last_prefetch_start_ms = 0;
+    this->state_.pipeline_blocked_since_ms = 0;
+    this->state_.pipeline_blocked_tracking = false;
+    this->state_.target_slot = this->state_.active_slot;
   }
 
   bool request_portrait_left_update(const PortraitState &portrait) {

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -674,6 +674,37 @@ interval:
       - if:
           condition:
             lambda: |-
+              const uint32_t now = millis();
+              const bool eligible = id(immich_fetch_started) && !id(backlight_paused) && !id(photo_source_menu_open);
+              if (!eligible) {
+                id(espframe_core).slideshow().pipeline_watchdog_timed_out(now, false, false);
+                return false;
+              }
+              id(slideshow_interval_sec) = parse_duration_option_seconds(
+                id(slideshow_interval).current_option(), id(slideshow_interval_sec), 10, 86400);
+              const bool advance_due =
+                (now - id(espframe_core).slideshow().state().last_advance_ms) >= (id(slideshow_interval_sec) * 1000);
+              if (!id(espframe_core).slideshow().state().active_slot_displayed) {
+                id(espframe_core).slideshow().pipeline_watchdog_timed_out(now, advance_due, false);
+                return false;
+              }
+              const bool image_busy = id(immich_img_0).is_downloading() ||
+                                      id(immich_img_1).is_downloading() ||
+                                      id(immich_img_2).is_downloading() ||
+                                      id(immich_portrait_left).is_downloading() ||
+                                      id(immich_portrait_right).is_downloading() ||
+                                      id(immich_portrait_preload_left).is_downloading() ||
+                                      id(immich_portrait_preload_right).is_downloading();
+              const bool blocked = any_slot_fetch_in_flight(id(espframe_core).slideshow().state().slot_flags) || image_busy ||
+                                   id(espframe_core).slideshow().state().portrait.workflow_busy ||
+                                   id(espframe_core).slideshow().state().preload_noncritical_in_flight ||
+                                   id(espframe_core).slideshow().state().noncritical_remote_updates_in_flight > 0;
+              return id(espframe_core).slideshow().pipeline_watchdog_timed_out(now, advance_due, blocked);
+          then:
+            - script.execute: recover_stalled_slideshow
+      - if:
+          condition:
+            lambda: |-
               if (!id(immich_fetch_started)) return false;
               if (id(backlight_paused)) return false;
               if (id(photo_source_menu_open)) return false;

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -628,8 +628,15 @@ static void test_slideshow_component_prefetch_and_deferred_updates() {
   assert(cmd.kind == SLIDESHOW_COMMAND_UPDATE_SLOT_IMAGE);
   assert(cmd.slot == 1);
 
-  clear_slot_fetch_in_flight(1, flags);
-  clear_noncritical(1, flags, noncritical_count);
+  slideshow.defer_slot_update_due_to_busy(1, flags, noncritical_count);
+  assert(!flags.fetch_in_flight[1]);
+  assert(flags.fetch_started_ms[1] == 0);
+  assert(!flags.noncritical_update[1]);
+  assert(noncritical_count == 0);
+  assert(slideshow.pop_command(cmd));
+  assert(cmd.kind == SLIDESHOW_COMMAND_PREFETCH_AFTER_DELAY);
+  assert(cmd.slot == 1);
+
   update = slideshow.request_deferred_slot_update(2, 0, flags, true, noncritical_count);
   assert(!update);
   assert(slideshow.pop_command(cmd));
@@ -649,6 +656,68 @@ static void test_slideshow_component_prefetch_and_deferred_updates() {
   assert(noncritical_count == 0);
   assert(slideshow.pop_command(cmd));
   assert(cmd.kind == SLIDESHOW_COMMAND_PREFETCH_AFTER_DELAY);
+}
+
+static void test_slideshow_pipeline_watchdog() {
+  EspFrameSlideshow slideshow;
+  auto &state = slideshow.state();
+  state.active_slot = 1;
+  state.target_slot = 2;
+  state.active_slot_displayed = true;
+  state.slot1 = make_slot("visible", false);
+  state.slot1.ready = true;
+  copy_slot_to_display(state.slot1, state.current_display);
+  state.slot_flags.fetch_in_flight[2] = true;
+  state.slot_flags.fetch_started_ms[2] = 1000;
+  state.slot_flags.noncritical_update[2] = true;
+  state.noncritical_remote_updates_in_flight = 2;
+  state.preload_noncritical_in_flight = true;
+  state.portrait.workflow_busy = true;
+  state.portrait_preload_slot = 2;
+  state.portrait_preload_left_ready = true;
+  state.portrait_preload_right_ready = false;
+  state.companion_target_slot = 2;
+  state.portrait_companion_url = "https://example.test/companion";
+  state.rejected_fetch_target = 0;
+  assert(slideshow.emit_command(SLIDESHOW_COMMAND_FETCH_INTO_SLOT, 2));
+
+  assert(!slideshow.pipeline_watchdog_timed_out(1000, true, true));
+  assert(state.pipeline_blocked_tracking);
+  assert(!slideshow.pipeline_watchdog_timed_out(
+      1000 + EspFrameSlideshow::PIPELINE_STALL_TIMEOUT_MS - 1, true, true));
+  assert(slideshow.pipeline_watchdog_timed_out(
+      1000 + EspFrameSlideshow::PIPELINE_STALL_TIMEOUT_MS, true, true));
+
+  slideshow.recover_stalled_pipeline();
+  assert(state.active_slot == 1);
+  assert(state.active_slot_displayed);
+  assert(state.slot1.ready);
+  assert(state.current_display.asset_id == "visible");
+  assert(state.target_slot == 1);
+  assert(!any_slot_fetch_in_flight(state.slot_flags));
+  assert(!state.slot_flags.noncritical_update[2]);
+  assert(state.noncritical_remote_updates_in_flight == 0);
+  assert(!state.preload_noncritical_in_flight);
+  assert(!state.portrait.workflow_busy);
+  assert(state.portrait_preload_slot == -1);
+  assert(state.companion_target_slot == -1);
+  assert(state.portrait_companion_url.empty());
+  assert(state.rejected_fetch_target == -1);
+  assert(!state.pipeline_blocked_tracking);
+  assert(!slideshow.has_command());
+
+  assert(!slideshow.pipeline_watchdog_timed_out(5000, true, true));
+  assert(state.pipeline_blocked_tracking);
+  assert(!slideshow.pipeline_watchdog_timed_out(6000, false, true));
+  assert(!state.pipeline_blocked_tracking);
+  assert(!slideshow.pipeline_watchdog_timed_out(7000, true, true));
+  assert(!slideshow.pipeline_watchdog_timed_out(8000, true, false));
+  assert(!state.pipeline_blocked_tracking);
+
+  const uint32_t wrap_start = 0xFFFFFF00u;
+  assert(!slideshow.pipeline_watchdog_timed_out(wrap_start, true, true));
+  const uint32_t wrap_timeout = wrap_start + EspFrameSlideshow::PIPELINE_STALL_TIMEOUT_MS;
+  assert(slideshow.pipeline_watchdog_timed_out(wrap_timeout, true, true));
 }
 
 static void test_slideshow_component_portrait_flow() {
@@ -1161,6 +1230,7 @@ int main() {
   test_fetch_queue_and_error_handling();
   test_slideshow_component_commands();
   test_slideshow_component_prefetch_and_deferred_updates();
+  test_slideshow_pipeline_watchdog();
   test_slideshow_component_portrait_flow();
   test_slideshow_component_preload_flow();
   test_slideshow_component_navigation_flow();


### PR DESCRIPTION
## Summary

- clear stale fetch and noncritical flags when a deferred slot update finds another download active
- add a 90-second slideshow pipeline watchdog that preserves the currently visible image while resetting transient work
- log watchdog recovery and restart prefetching
- add regression coverage for the deferral race, timeout/reset behavior, and `millis()` wraparound

Fixes #172

## Validation

- `npm run test:helpers`
- `npm run check:fast`
- documentation build
- timezone validation
- ESPHome 2026.7.4 factory compile: Guition 10-inch original
- ESPHome 2026.7.4 factory compile: Guition 10-inch v2

The browser portion of `npm run check:pr` was not run locally because Chrome/Chromium is unavailable in the environment.