### PR TITLE
Fix firmware update detection and auto-install

### DIFF
--- a/common/addon/firmware_update.yaml
+++ b/common/addon/firmware_update.yaml
@@ -51,6 +51,21 @@ globals:
     initial_value: 'false'
 
 script:
+  - id: firmware_auto_install_available_update
+    mode: single
+    then:
+      - if:
+          condition:
+            and:
+              - switch.is_on: auto_update_switch
+              - lambda: 'return !id(manual_check_only);'
+              - update.is_available: firmware_update
+          then:
+            - lambda: |-
+                id(firmware_update_reboot_pending) = true;
+                global_preferences->sync();
+            - update.perform: firmware_update
+
   - id: firmware_update_recover_display
     mode: restart
     then:
@@ -116,14 +131,7 @@ update:
     update_interval: never
     on_update_available:
       then:
-        - if:
-            condition:
-              lambda: 'return id(auto_update_switch).state && !id(manual_check_only);'
-            then:
-              - lambda: |-
-                  id(firmware_update_reboot_pending) = true;
-                  global_preferences->sync();
-              - update.perform: firmware_update
+        - script.execute: firmware_auto_install_available_update
 
 # -----------------------------------------------------------------------------
 # User controls: auto-update and check frequency
@@ -140,6 +148,14 @@ switch:
     # ESPFRAME:SETTING_FIELDS auto_update END
     web_server:
       sorting_group_id: sg_firmware
+    on_turn_on:
+      - if:
+          condition:
+            update.is_available: firmware_update
+          then:
+            - script.execute: firmware_auto_install_available_update
+          else:
+            - update.check: firmware_update
 
 select:
   - platform: template
@@ -166,18 +182,26 @@ select:
 interval:
   - interval: 1h
     then:
-      - lambda: |-
-          if (!id(auto_update_switch).state) return;
-          int counter = id(update_check_counter);
-          std::string freq = id(update_frequency_select).current_option();
-          int threshold = 24;
-          if (freq == "Hourly") threshold = 1;
-          else if (freq == "Weekly") threshold = 168;
-          else if (freq == "Monthly") threshold = 720;
-          if (counter % threshold == 0) {
-            id(firmware_update).update();
-          }
-          id(update_check_counter) = counter + 1;
+      - if:
+          condition:
+            lambda: |-
+              if (!id(auto_update_switch).state) return false;
+              int counter = id(update_check_counter);
+              std::string freq = id(update_frequency_select).current_option();
+              int threshold = 24;
+              if (freq == "Hourly") threshold = 1;
+              else if (freq == "Weekly") threshold = 168;
+              else if (freq == "Monthly") threshold = 720;
+              id(update_check_counter) = counter + 1;
+              return counter % threshold == 0;
+          then:
+            - if:
+                condition:
+                  update.is_available: firmware_update
+                then:
+                  - script.execute: firmware_auto_install_available_update
+                else:
+                  - update.check: firmware_update
 
 # -----------------------------------------------------------------------------
 # Exposed version and manual check button
@@ -239,6 +263,8 @@ button:
       sorting_group_id: sg_firmware
     on_press:
       - lambda: 'id(manual_check_only) = true;'
-      - component.update: firmware_update
-      - delay: 15s
+      - update.check: firmware_update
+      # Keep automatic installation suppressed for longer than the configured
+      # 20-second HTTP timeout so a slow manual check remains check-only.
+      - delay: 30s
       - lambda: 'id(manual_check_only) = false;'

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/dev.yaml
@@ -16,3 +16,14 @@ wifi:
 
 packages:
   espframe: !include packages.yaml
+
+# Development flashes must serve the web bundle from this checkout so UI
+# changes can be tested on the display before they are published to GitHub
+# Pages. Release build wrappers apply the same local-bundle override.
+web_server:
+  port: 80
+  version: 3
+  include_internal: true
+  js_url: ""
+  css_include: "../../docs/public/webserver/style.css"
+  js_include: "../../docs/public/webserver/app.js"

--- a/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -16,3 +16,14 @@ wifi:
 
 packages:
   espframe: !include packages.yaml
+
+# Development flashes must serve the web bundle from this checkout so UI
+# changes can be tested on the display before they are published to GitHub
+# Pages. Release build wrappers apply the same local-bundle override.
+web_server:
+  port: 80
+  version: 3
+  include_internal: true
+  js_url: ""
+  css_include: "../../docs/public/webserver/style.css"
+  js_include: "../../docs/public/webserver/app.js"

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -3397,6 +3397,21 @@ to {
     refreshFirmwareUi();
     return S.update_available;
   }
+  function firmwareUpdateResponseResolved(data) {
+    if (!data) return false;
+    var state = String(data.state || "").trim().toUpperCase();
+    return state === "UPDATE AVAILABLE" || state === "NO UPDATE" || state === "INSTALLING" || !!String(data.latest_version || data.value || "").trim();
+  }
+  function waitForFirmwareUpdateResponse(attemptsRemaining) {
+    return delayMs(2e3).then(function() {
+      return safeGet(endpoints.update);
+    }).catch(function() {
+      return null;
+    }).then(function(data) {
+      if (firmwareUpdateResponseResolved(data) || attemptsRemaining <= 1) return data;
+      return waitForFirmwareUpdateResponse(attemptsRemaining - 1);
+    });
+  }
   function markFirmwareRestartPending() {
     S.firmware_uploading = false;
     S.firmware_installing = true;
@@ -3477,12 +3492,19 @@ to {
     S.firmware_install_error = "";
     S.firmware_checking = true;
     refreshFirmwareUi();
-    post(endpoints.firmware_check + "/press").then(function() {
-      return delayMs(4e3);
-    }).then(function() {
-      return safeGet(endpoints.update);
-    }).then(function(data) {
-      var available = applyFirmwareUpdateResponse(data);
+    var deviceCheck = post(endpoints.firmware_check + "/press").then(function() {
+      return waitForFirmwareUpdateResponse(12);
+    }).catch(function() {
+      return null;
+    });
+    var publicCheck = fetchPublicFirmwareVersions();
+    Promise.all([deviceCheck, publicCheck]).then(function(results) {
+      var data = firmwareUpdateResponseResolved(results[0]) ? results[0] : null;
+      var publicVersions = results[1];
+      if (!data && !publicVersions.length) {
+        throw new Error("firmware_check_unavailable");
+      }
+      var available = data ? applyFirmwareUpdateResponse(data) : firmwareUpdateKnownAvailable();
       S.firmware_checking = false;
       if (installAfterCheck && available) startFirmwareInstall();
       else refreshFirmwareUi();
@@ -3490,7 +3512,6 @@ to {
       S.firmware_checking = false;
       failFirmwareInstall("Could not check for a firmware update.");
     });
-    fetchPublicFirmwareVersions();
   }
   function refreshC6FirmwareState() {
     return Promise.all([

--- a/docs/webserver/src/settings_firmware_card.ts
+++ b/docs/webserver/src/settings_firmware_card.ts
@@ -260,6 +260,23 @@
     return S.update_available;
   }
 
+  function firmwareUpdateResponseResolved(data) {
+    if (!data) return false;
+    var state = String(data.state || "").trim().toUpperCase();
+    return state === "UPDATE AVAILABLE" || state === "NO UPDATE" || state === "INSTALLING" ||
+      !!String(data.latest_version || data.value || "").trim();
+  }
+
+  function waitForFirmwareUpdateResponse(attemptsRemaining) {
+    return delayMs(2000)
+      .then(function () { return safeGet(endpoints.update); })
+      .catch(function () { return null; })
+      .then(function (data) {
+        if (firmwareUpdateResponseResolved(data) || attemptsRemaining <= 1) return data;
+        return waitForFirmwareUpdateResponse(attemptsRemaining - 1);
+      });
+  }
+
   function markFirmwareRestartPending() {
     S.firmware_uploading = false;
     S.firmware_installing = true;
@@ -347,11 +364,18 @@
     S.firmware_install_error = "";
     S.firmware_checking = true;
     refreshFirmwareUi();
-    post(endpoints.firmware_check + "/press")
-      .then(function () { return delayMs(4000); })
-      .then(function () { return safeGet(endpoints.update); })
-      .then(function (data) {
-        var available = applyFirmwareUpdateResponse(data);
+    var deviceCheck = post(endpoints.firmware_check + "/press")
+      .then(function () { return waitForFirmwareUpdateResponse(12); })
+      .catch(function () { return null; });
+    var publicCheck = fetchPublicFirmwareVersions();
+    Promise.all([deviceCheck, publicCheck])
+      .then(function (results) {
+        var data = firmwareUpdateResponseResolved(results[0]) ? results[0] : null;
+        var publicVersions = results[1];
+        if (!data && !publicVersions.length) {
+          throw new Error("firmware_check_unavailable");
+        }
+        var available = data ? applyFirmwareUpdateResponse(data) : firmwareUpdateKnownAvailable();
         S.firmware_checking = false;
         if (installAfterCheck && available) startFirmwareInstall();
         else refreshFirmwareUi();
@@ -360,7 +384,6 @@
         S.firmware_checking = false;
         failFirmwareInstall("Could not check for a firmware update.");
       });
-    fetchPublicFirmwareVersions();
   }
 
   function refreshC6FirmwareState() {

--- a/scripts/product_contract/build_outputs.py
+++ b/scripts/product_contract/build_outputs.py
@@ -268,6 +268,23 @@ def check_web_server_metadata(product: dict, errors: list[str]) -> None:
                     require_contains(device_text, f'      name: "{name}"', device_yaml, errors)
                 if isinstance(weight, int) and not isinstance(weight, bool):
                     require_contains(device_text, f"      sorting_weight: {weight}", device_yaml, errors)
+            dev_yaml_path = (ROOT / device_yaml).parent.parent / "dev.yaml"
+            if dev_yaml_path.is_file():
+                dev_yaml = rel(dev_yaml_path)
+                dev_text = read(dev_yaml_path, errors)
+                require_contains(dev_text, '  js_url: ""', dev_yaml, errors)
+                require_contains(
+                    dev_text,
+                    '  css_include: "../../docs/public/webserver/style.css"',
+                    dev_yaml,
+                    errors,
+                )
+                require_contains(
+                    dev_text,
+                    '  js_include: "../../docs/public/webserver/app.js"',
+                    dev_yaml,
+                    errors,
+                )
         if build_yaml:
             build_text = read(ROOT / build_yaml, errors)
             if isinstance(port, int) and not isinstance(port, bool):

--- a/scripts/product_contract/firmware_updates.py
+++ b/scripts/product_contract/firmware_updates.py
@@ -72,7 +72,7 @@ def check_firmware_update_metadata(product: dict, errors: list[str]) -> None:
     if manual_check_behavior:
         require_contains(firmware_docs, manual_check_behavior, "docs/firmware-update.md", errors)
         require_contains(firmware_yaml, "manual_check_only", "common/addon/firmware_update.yaml", errors)
-        require_contains(firmware_yaml, "component.update: firmware_update", "common/addon/firmware_update.yaml", errors)
+        require_contains(firmware_yaml, "update.check: firmware_update", "common/addon/firmware_update.yaml", errors)
         require_contains(web_template, 'post(endpoints.firmware_check + "/press")', rel(WEB_TEMPLATE), errors)
     if isinstance(frequency_hours, dict):
         for label, hours in frequency_hours.items():
@@ -87,7 +87,10 @@ def check_firmware_update_metadata(product: dict, errors: list[str]) -> None:
             require_contains(firmware_yaml, f"threshold = {hours}", "common/addon/firmware_update.yaml", errors)
     for needle in (
         "update.perform: firmware_update",
-        "id(auto_update_switch).state && !id(manual_check_only)",
+        "firmware_auto_install_available_update",
+        "update.is_available: firmware_update",
+        "switch.is_on: auto_update_switch",
+        "return !id(manual_check_only);",
         "id(firmware_update_reboot_pending) = true;",
         "update_interval: never",
     ):

--- a/tests/web_module_tests.js
+++ b/tests/web_module_tests.js
@@ -66,4 +66,13 @@ assert.ok(
   "live state events should be resolved by name_id, not the legacy object-id form"
 );
 
+assert.ok(
+  publicApp.includes("Promise.all([deviceCheck, publicCheck])"),
+  "firmware checks should accept the public release index when the device update entity is slow or unavailable"
+);
+assert.ok(
+  publicApp.includes("waitForFirmwareUpdateResponse(12)"),
+  "firmware checks should wait for the asynchronous device update result instead of reading UNKNOWN once"
+);
+
 console.log("web module tests passed");


### PR DESCRIPTION
## Summary

- wait for asynchronous firmware checks to resolve instead of reading `UNKNOWN` once
- install already-detected updates when automatic updates are enabled or due
- use ESPHome update actions consistently and keep manual checks check-only
- embed the local web bundle in both development configurations
- add contract and bundle regression coverage

## Validation

- `npm run check:fast`
- `npm run test:web-modules`
- `npm run test:web-compat`
- `npm run test:web-smoke-cli`
- `npm run webserver:typecheck`
- package, product-contract, release-readiness, workflow, budget, helper, and docs checks
- ESPHome 2026.7.4 configuration validation for both panel revisions
- compiled and OTA-flashed the original-panel development config
- live device check resolved `v1.12.4` as `UPDATE AVAILABLE` on the first poll

## Environment limitations

- browser smoke could not run locally because Chrome/Chromium is not installed
- timezone validation is blocked locally by the missing `tzdata` alias `Asia/Rangoon`
