### PR TITLE
Add swipe navigation for image sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Espframe is for people who want their photos out in the room, not hidden on a ph
   Adjust brightness, warm up a panel that looks too blue, use a softer night tone after sunset, and schedule the display to turn off overnight.
 
 - **Control it from the frame or a browser**  
-  Use simple touch gestures to wake, sleep, or advance to the next photo. Open the built-in web page on your phone or computer to change photo sources, timing, brightness, Immich settings, and display options.
+  Use simple touch gestures to wake, sleep, or advance to the next photo, and swipe between image sets. Open the built-in web page on your phone or computer to change photo sources, timing, brightness, Immich settings, and display options.
 
 - **Use Home Assistant if you want to, but it is not required**  
   Espframe works by itself. If you already use Home Assistant, it can also appear there as an ESPHome device for dashboard controls, automations, and updates.
@@ -75,7 +75,7 @@ The full setup guide is here:
 
 Once installed, the frame has two main control surfaces:
 
-- **On the touchscreen:** tap to wake, double-tap to advance to the next photo, and press-and-hold to sleep.
+- **On the touchscreen:** tap to wake, double-tap to advance to the next photo, swipe left for the next image set, swipe right for the previous image set, and press-and-hold to sleep.
 - **In the web settings page:** change the photo source, slideshow speed, date filters, brightness, screen tone, rotation, WiFi, Immich connection, and firmware update options.
 
 ## Development

--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -829,6 +829,7 @@ script:
             not:
               wifi.connected:
           then:
+            - lambda: 'id(espframe_core).slideshow().mark_portrait_search_request_finished();'
             - logger.log:
                 level: DEBUG
                 tag: immich
@@ -838,6 +839,7 @@ script:
           condition:
             lambda: 'return id(immich_url).state.empty() || id(immich_api_key_text).state.empty();'
           then:
+            - lambda: 'id(espframe_core).slideshow().mark_portrait_search_request_finished();'
             - script.stop: immich_fetch_portrait_companion
       - if:
           condition:
@@ -871,6 +873,7 @@ script:
           std::string dt = id(espframe_core).slideshow().state().portrait_search_datetime;
           if (dt.size() < 10) {
             ESP_LOGW("immich", "No datetime for companion search");
+            id(espframe_core).slideshow().mark_portrait_search_request_finished();
             id(handle_companion_not_found).execute();
             return;
           }
@@ -918,6 +921,7 @@ script:
                     ESP_LOGW("immich", "Companion search HTTP %d", response->status_code);
                     id(espframe_core).slideshow().state().diagnostic_reason = "companion search http";
                     id(log_immich_diag).execute();
+                    id(espframe_core).slideshow().mark_portrait_search_request_finished();
                     id(handle_companion_not_found).execute();
                     return;
                   }
@@ -934,6 +938,7 @@ script:
                       return;
                     }
                     ESP_LOGI("immich", "NO COMPANION found for slot %d", id(espframe_core).slideshow().state().companion_target_slot);
+                    id(espframe_core).slideshow().mark_portrait_search_request_finished();
                     id(handle_companion_not_found).execute();
                     return;
                   }
@@ -942,6 +947,7 @@ script:
                     id(espframe_core).slideshow().state().companion_target_slot, id(espframe_core).slideshow().state().active_slot, id(espframe_core).slideshow().state().slot0, id(espframe_core).slideshow().state().slot1, id(espframe_core).slideshow().state().slot2,
                     id(espframe_core).slideshow().state().portrait_preload_slot, id(espframe_core).slideshow().state().portrait_preload_left_ready,
                     id(espframe_core).slideshow().state().portrait_preload_right_ready);
+                  id(espframe_core).slideshow().mark_portrait_search_request_finished();
                   id(espframe_slideshow_dispatch).execute();
           on_error:
             then:
@@ -953,5 +959,6 @@ script:
                   ESP_LOGW("immich", "Companion search request failed");
                   id(espframe_core).slideshow().state().diagnostic_reason = "companion search error";
                   id(log_immich_diag).execute();
+                  id(espframe_core).slideshow().mark_portrait_search_request_finished();
                   id(handle_companion_not_found).execute();
       - script.execute: delayed_prefetch_chain

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -326,12 +326,14 @@ remote_image:
       then:
         - lambda: |-
             ESP_LOGE("immich", "Portrait preload left failed");
+            int failed_preload_slot = id(espframe_core).slideshow().state().portrait_preload_slot;
             id(espframe_core).slideshow().on_preload_left_error(
-              id(espframe_core).slideshow().state().diagnostic_reason, id(espframe_core).slideshow().state().portrait_preload_left_ready,
+              id(espframe_core).slideshow().state().diagnostic_reason, id(espframe_core).slideshow().state().portrait_preload_slot,
+              id(espframe_core).slideshow().state().portrait_preload_left_ready, id(espframe_core).slideshow().state().portrait_preload_right_ready,
               id(espframe_core).slideshow().state().preload_noncritical_in_flight, id(espframe_core).slideshow().state().noncritical_remote_updates_in_flight);
-            if (id(portrait_pairs_only).state && id(espframe_core).slideshow().state().portrait_preload_slot >= 0) {
+            if (id(portrait_pairs_only).state && failed_preload_slot >= 0) {
               id(espframe_core).slideshow().reject_portrait_slot(
-                millis(), id(espframe_core).slideshow().state().portrait_preload_slot);
+                millis(), failed_preload_slot);
             }
             id(espframe_slideshow_dispatch).execute();
 
@@ -356,12 +358,14 @@ remote_image:
       then:
         - lambda: |-
             ESP_LOGE("immich", "Portrait preload right failed");
+            int failed_preload_slot = id(espframe_core).slideshow().state().portrait_preload_slot;
             id(espframe_core).slideshow().on_preload_right_error(
-              id(espframe_core).slideshow().state().diagnostic_reason, id(espframe_core).slideshow().state().portrait_preload_right_ready,
+              id(espframe_core).slideshow().state().diagnostic_reason, id(espframe_core).slideshow().state().portrait_preload_slot,
+              id(espframe_core).slideshow().state().portrait_preload_left_ready, id(espframe_core).slideshow().state().portrait_preload_right_ready,
               id(espframe_core).slideshow().state().preload_noncritical_in_flight, id(espframe_core).slideshow().state().noncritical_remote_updates_in_flight);
-            if (id(portrait_pairs_only).state && id(espframe_core).slideshow().state().portrait_preload_slot >= 0) {
+            if (id(portrait_pairs_only).state && failed_preload_slot >= 0) {
               id(espframe_core).slideshow().reject_portrait_slot(
-                millis(), id(espframe_core).slideshow().state().portrait_preload_slot);
+                millis(), failed_preload_slot);
             }
             id(espframe_slideshow_dispatch).execute();
 

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -21,6 +21,9 @@ globals:
   - id: last_short_tap_ms
     type: uint32_t
     initial_value: '0'
+  - id: slideshow_swipe_suppress_tap_until_ms
+    type: uint32_t
+    initial_value: '0'
   - id: last_photo_displayed_ms
     type: uint32_t
     initial_value: '0'

--- a/components/espframe/slideshow_component.h
+++ b/components/espframe/slideshow_component.h
@@ -312,9 +312,13 @@ class EspFrameSlideshow {
     this->clear_preload_noncritical_(preload_noncritical_in_flight, noncritical_count);
   }
 
-  void on_preload_left_error(std::string &diag_reason, bool &portrait_preload_left_ready,
+  void on_preload_left_error(std::string &diag_reason, int &portrait_preload_slot,
+                             bool &portrait_preload_left_ready,
+                             bool &portrait_preload_right_ready,
                              bool &preload_noncritical_in_flight, int &noncritical_count) {
+    portrait_preload_slot = -1;
     portrait_preload_left_ready = false;
+    portrait_preload_right_ready = false;
     diag_reason = "portrait preload left error";
     this->clear_preload_noncritical_(preload_noncritical_in_flight, noncritical_count);
     this->emit_command(SLIDESHOW_COMMAND_LOG_DIAG);
@@ -327,8 +331,12 @@ class EspFrameSlideshow {
     this->clear_preload_noncritical_(preload_noncritical_in_flight, noncritical_count);
   }
 
-  void on_preload_right_error(std::string &diag_reason, bool &portrait_preload_right_ready,
+  void on_preload_right_error(std::string &diag_reason, int &portrait_preload_slot,
+                              bool &portrait_preload_left_ready,
+                              bool &portrait_preload_right_ready,
                               bool &preload_noncritical_in_flight, int &noncritical_count) {
+    portrait_preload_slot = -1;
+    portrait_preload_left_ready = false;
     portrait_preload_right_ready = false;
     diag_reason = "portrait preload right error";
     this->clear_preload_noncritical_(preload_noncritical_in_flight, noncritical_count);

--- a/components/espframe/slideshow_component.h
+++ b/components/espframe/slideshow_component.h
@@ -115,6 +115,7 @@ struct SlideshowRuntimeState {
   int portrait_preload_slot = -1;
   bool portrait_preload_left_ready = false;
   bool portrait_preload_right_ready = false;
+  bool portrait_search_in_flight = false;
   bool portrait_search_expanded = false;
   uint32_t portrait_search_generation = 0;
   uint32_t portrait_search_request_generation = 0;
@@ -180,6 +181,7 @@ class EspFrameSlideshow {
         companion_target_slot, portrait_preload_slot, portrait_search_datetime,
         portrait_primary_asset_id);
     if (action == SLIDESHOW_ACTION_FETCH_COMPANION) {
+      this->state_.portrait_search_in_flight = true;
       this->state_.portrait_search_expanded = false;
       this->state_.portrait_search_generation++;
     }
@@ -229,6 +231,7 @@ class EspFrameSlideshow {
     portrait_companion_url = "";
     portrait_search_datetime = meta.datetime;
     companion_target_slot = active_slot;
+    this->state_.portrait_search_in_flight = true;
     portrait_search_expanded = false;
     this->state_.portrait_search_generation++;
     this->emit_command(SLIDESHOW_COMMAND_DEFER_COMPANION_SEARCH, active_slot, 200);
@@ -433,7 +436,7 @@ class EspFrameSlideshow {
       this->emit_command(SLIDESHOW_COMMAND_LOG_NO_PREVIOUS);
       return false;
     }
-    if (any_slot_fetch_in_flight(flags)) return false;
+    if (this->previous_navigation_blocked(active_slot, portrait, flags)) return false;
 
     int current_slot = active_slot;
     SlotMeta &current_meta = this->slot_mut_(current_slot, slot0, slot1, slot2);
@@ -456,6 +459,15 @@ class EspFrameSlideshow {
 
     this->emit_command(SLIDESHOW_COMMAND_LOAD_PREVIOUS_SLOT, previous_slot);
     return true;
+  }
+
+  bool previous_navigation_blocked(int active_slot, const PortraitState &portrait,
+                                   const SlotFlags &flags) const {
+    int previous_slot = (active_slot + 2) % 3;
+    return any_slot_fetch_in_flight(flags) || portrait.workflow_busy ||
+           (this->state_.portrait_search_in_flight &&
+            this->state_.companion_target_slot == previous_slot) ||
+           this->state_.portrait_preload_slot == previous_slot;
   }
 
   void handle_companion_not_found(PortraitState &portrait,
@@ -588,7 +600,10 @@ class EspFrameSlideshow {
       this->state_.active_slot_displayed = false;
       this->state_.portrait = PortraitState{};
     }
-    if (this->state_.companion_target_slot == slot) this->state_.companion_target_slot = -1;
+    if (this->state_.companion_target_slot == slot) {
+      this->state_.companion_target_slot = -1;
+      this->state_.portrait_search_in_flight = false;
+    }
     this->state_.portrait_companion_url.clear();
     // Keep target_slot bound to any request already in flight. The delayed
     // rejected-slot fetch claims target_slot only after the current request
@@ -601,12 +616,18 @@ class EspFrameSlideshow {
   }
 
   void mark_portrait_search_request_started() {
+    this->state_.portrait_search_in_flight = true;
     this->state_.portrait_search_request_generation =
         this->state_.portrait_search_generation;
   }
 
+  void mark_portrait_search_request_finished() {
+    this->state_.portrait_search_in_flight = false;
+  }
+
   bool portrait_search_response_is_current() const {
-    return this->state_.companion_target_slot >= 0 &&
+    return this->state_.portrait_search_in_flight &&
+           this->state_.companion_target_slot >= 0 &&
            this->state_.companion_target_slot <= 2 &&
            this->state_.portrait_search_request_generation ==
                this->state_.portrait_search_generation;
@@ -723,6 +744,7 @@ class EspFrameSlideshow {
     this->state_.portrait_preload_slot = -1;
     this->state_.portrait_preload_left_ready = false;
     this->state_.portrait_preload_right_ready = false;
+    this->state_.portrait_search_in_flight = false;
     this->state_.portrait_search_expanded = false;
     this->state_.portrait_search_generation++;
     this->state_.portrait_search_request_generation = 0;

--- a/components/espframe/slideshow_component.h
+++ b/components/espframe/slideshow_component.h
@@ -433,6 +433,7 @@ class EspFrameSlideshow {
       this->emit_command(SLIDESHOW_COMMAND_LOG_NO_PREVIOUS);
       return false;
     }
+    if (any_slot_fetch_in_flight(flags)) return false;
 
     int current_slot = active_slot;
     SlotMeta &current_meta = this->slot_mut_(current_slot, slot0, slot1, slot2);

--- a/components/espframe/slideshow_component.h
+++ b/components/espframe/slideshow_component.h
@@ -438,6 +438,14 @@ class EspFrameSlideshow {
     }
     if (this->previous_navigation_blocked(active_slot, portrait, flags)) return false;
 
+    int previous_slot = (active_slot + 2) % 3;
+    this->clear_preload_for_slot(
+        previous_slot, this->state_.portrait_preload_slot,
+        this->state_.portrait_preload_left_ready,
+        this->state_.portrait_preload_right_ready,
+        this->state_.preload_noncritical_in_flight,
+        this->state_.noncritical_remote_updates_in_flight);
+
     int current_slot = active_slot;
     SlotMeta &current_meta = this->slot_mut_(current_slot, slot0, slot1, slot2);
     DisplayMeta tmp = current_display;
@@ -447,7 +455,6 @@ class EspFrameSlideshow {
     prev_display = tmp;
 
     portrait = PortraitState{};
-    int previous_slot = (active_slot + 2) % 3;
     active_slot = previous_slot;
     active_slot_displayed = false;
 
@@ -464,10 +471,14 @@ class EspFrameSlideshow {
   bool previous_navigation_blocked(int active_slot, const PortraitState &portrait,
                                    const SlotFlags &flags) const {
     int previous_slot = (active_slot + 2) % 3;
+    bool incomplete_preload_targets_previous =
+        this->state_.portrait_preload_slot == previous_slot &&
+        !(this->state_.portrait_preload_left_ready &&
+          this->state_.portrait_preload_right_ready);
     return any_slot_fetch_in_flight(flags) || portrait.workflow_busy ||
            (this->state_.portrait_search_in_flight &&
             this->state_.companion_target_slot == previous_slot) ||
-           this->state_.portrait_preload_slot == previous_slot;
+           incomplete_preload_targets_previous;
   }
 
   void handle_companion_not_found(PortraitState &portrait,

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -500,7 +500,10 @@ touchscreen:
             if (horizontal_delta < 0) {
               id(show_slideshow_navigation_feedback).execute(1);
               id(immich_advance_forward).execute();
-            } else if (any_slot_fetch_in_flight(id(espframe_core).slideshow().state().slot_flags)) {
+            } else if (id(espframe_core).slideshow().previous_navigation_blocked(
+                         id(espframe_core).slideshow().state().active_slot,
+                         id(espframe_core).slideshow().state().portrait,
+                         id(espframe_core).slideshow().state().slot_flags)) {
               id(show_slideshow_navigation_feedback).execute(0);
             } else {
               id(show_slideshow_navigation_feedback).execute(-1);

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -500,6 +500,8 @@ touchscreen:
             if (horizontal_delta < 0) {
               id(show_slideshow_navigation_feedback).execute(1);
               id(immich_advance_forward).execute();
+            } else if (any_slot_fetch_in_flight(id(espframe_core).slideshow().state().slot_flags)) {
+              id(show_slideshow_navigation_feedback).execute(0);
             } else {
               id(show_slideshow_navigation_feedback).execute(-1);
               id(immich_show_previous).execute();
@@ -515,4 +517,8 @@ touchscreen:
           }
     on_release:
       - lambda: |-
-          id(photo_source_swipe_triggered) = false; id(photo_source_menu_touch_handled) = false;
+          if (id(photo_source_swipe_triggered)) {
+            id(slideshow_swipe_suppress_tap_until_ms) = millis() + 250;
+          }
+          id(photo_source_swipe_triggered) = false;
+          id(photo_source_menu_touch_handled) = false;

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -519,6 +519,7 @@ touchscreen:
       - lambda: |-
           if (id(photo_source_swipe_triggered)) {
             id(slideshow_swipe_suppress_tap_until_ms) = millis() + 250;
+            id(clear_slideshow_swipe_tap_suppression).execute();
           }
           id(photo_source_swipe_triggered) = false;
           id(photo_source_menu_touch_handled) = false;

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -426,7 +426,6 @@ touchscreen:
       - script.execute: backlight_wake
     on_update:
       - lambda: |-
-          if (!id(developer_features_enabled).state) return;
           if (touches.empty()) return;
           const auto &touch = touches.front();
           auto map_visible = [](int x, int y, int &screen_x, int &screen_y) {
@@ -445,7 +444,7 @@ touchscreen:
               screen_y = y;
             }
           };
-          if (id(photo_source_menu_open)) {
+          if (id(photo_source_menu_open) && id(developer_features_enabled).state) {
             if (id(photo_source_swipe_triggered) || id(photo_source_menu_touch_handled)) return;
             auto hit_at = [&](lv_obj_t *obj, int x, int y) -> bool {
               lv_area_t coords;
@@ -485,6 +484,29 @@ touchscreen:
           int start_x, start_y, current_x, current_y;
           map_visible(touch.x_org, touch.y_org, start_x, start_y);
           map_visible(touch.x, touch.y, current_x, current_y);
+          const int horizontal_delta = current_x - start_x;
+          const int vertical_delta = current_y - start_y;
+          const int horizontal_distance = std::abs(horizontal_delta);
+          const int vertical_distance = std::abs(vertical_delta);
+          const bool slideshow_visible = lv_scr_act() == id(slideshow_page)->obj &&
+            lv_obj_has_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN) &&
+            !id(photo_source_menu_open);
+          if (slideshow_visible && !id(touch_started_while_off) &&
+              horizontal_distance >= 120 && horizontal_distance > (vertical_distance * 3) / 2) {
+            id(photo_source_swipe_triggered) = true;
+            id(slideshow_swipe_suppress_tap_until_ms) = millis() + 700;
+            id(last_short_tap_ms) = 0;
+            id(backlight_hold_timer).stop();
+            if (horizontal_delta < 0) {
+              id(show_slideshow_navigation_feedback).execute(1);
+              id(immich_advance_forward).execute();
+            } else {
+              id(show_slideshow_navigation_feedback).execute(-1);
+              id(immich_show_previous).execute();
+            }
+            return;
+          }
+          if (!id(developer_features_enabled).state) return;
           const int dy = current_y - start_y;
           const int dx = std::abs(current_x - start_x);
           if (start_y <= 140 && dy >= 110 && dx <= 220) {

--- a/devices/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
@@ -2,8 +2,8 @@
 # ICONS - Material Design Icons for setup and UI
 # =============================================================================
 # Single icon font (MaterialDesign-Webfont) with glyphs used by the device
-# screens. Substitutions expose Unicode codepoints for WiFi and cog (settings)
-# so other YAML can reference icon_wifi / icon_cog without hardcoding.
+# screens. Substitutions expose Unicode codepoints so other YAML can reference
+# icons without hardcoding them.
 # =============================================================================
 
 font:
@@ -15,11 +15,15 @@ font:
       - "\U000F05A9"  # mdi-wifi
       - "\U000F0493"  # mdi-cog
       - "\U000F0164"  # mdi-cloud-off-outline
+      - "\U000F0141"  # mdi-chevron-left
+      - "\U000F0142"  # mdi-chevron-right
 
 # -----------------------------------------------------------------------------
-# Substitutions for use in labels/buttons (mdi-wifi, mdi-cog, mdi-cloud-off-outline)
+# Substitutions for use in labels/buttons
 # -----------------------------------------------------------------------------
 substitutions:
   icon_wifi: "\U000F05A9"
   icon_cog: "\U000F0493"
   icon_cloud_off: "\U000F0164"
+  icon_chevron_left: "\U000F0141"
+  icon_chevron_right: "\U000F0142"

--- a/devices/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
@@ -1,9 +1,9 @@
 # =============================================================================
 # ICONS - Material Design Icons for setup and UI
 # =============================================================================
-# Single icon font (MaterialDesign-Webfont) with glyphs used by the device
-# screens. Substitutions expose Unicode codepoints so other YAML can reference
-# icons without hardcoding them.
+# MaterialDesign-Webfont icon fonts used by the device screens. Substitutions
+# expose Unicode codepoints so other YAML can reference icons without
+# hardcoding them.
 # =============================================================================
 
 font:
@@ -15,6 +15,12 @@ font:
       - "\U000F05A9"  # mdi-wifi
       - "\U000F0493"  # mdi-cog
       - "\U000F0164"  # mdi-cloud-off-outline
+
+  - file: 'https://github.com/Templarian/MaterialDesign-Webfont/raw/v7.4.47/fonts/materialdesignicons-webfont.ttf'
+    id: icon_font_navigation
+    size: 56
+    bpp: 4
+    glyphs:
       - "\U000F0141"  # mdi-chevron-left
       - "\U000F0142"  # mdi-chevron-right
 

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -292,6 +292,8 @@ touchscreen:
             if (horizontal_delta < 0) {
               id(show_slideshow_navigation_feedback).execute(1);
               id(immich_advance_forward).execute();
+            } else if (any_slot_fetch_in_flight(id(espframe_core).slideshow().state().slot_flags)) {
+              id(show_slideshow_navigation_feedback).execute(0);
             } else {
               id(show_slideshow_navigation_feedback).execute(-1);
               id(immich_show_previous).execute();
@@ -307,4 +309,8 @@ touchscreen:
           }
     on_release:
       - lambda: |-
-          id(photo_source_swipe_triggered) = false; id(photo_source_menu_touch_handled) = false;
+          if (id(photo_source_swipe_triggered)) {
+            id(slideshow_swipe_suppress_tap_until_ms) = millis() + 250;
+          }
+          id(photo_source_swipe_triggered) = false;
+          id(photo_source_menu_touch_handled) = false;

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -218,7 +218,6 @@ touchscreen:
       - script.execute: backlight_wake
     on_update:
       - lambda: |-
-          if (!id(developer_features_enabled).state) return;
           if (touches.empty()) return;
           const auto &touch = touches.front();
           auto map_visible = [](int x, int y, int &screen_x, int &screen_y) {
@@ -237,7 +236,7 @@ touchscreen:
               screen_y = y;
             }
           };
-          if (id(photo_source_menu_open)) {
+          if (id(photo_source_menu_open) && id(developer_features_enabled).state) {
             if (id(photo_source_swipe_triggered) || id(photo_source_menu_touch_handled)) return;
             auto hit_at = [&](lv_obj_t *obj, int x, int y) -> bool {
               lv_area_t coords;
@@ -277,6 +276,29 @@ touchscreen:
           int start_x, start_y, current_x, current_y;
           map_visible(touch.x_org, touch.y_org, start_x, start_y);
           map_visible(touch.x, touch.y, current_x, current_y);
+          const int horizontal_delta = current_x - start_x;
+          const int vertical_delta = current_y - start_y;
+          const int horizontal_distance = std::abs(horizontal_delta);
+          const int vertical_distance = std::abs(vertical_delta);
+          const bool slideshow_visible = lv_scr_act() == id(slideshow_page)->obj &&
+            lv_obj_has_flag(id(connection_failed_overlay), LV_OBJ_FLAG_HIDDEN) &&
+            !id(photo_source_menu_open);
+          if (slideshow_visible && !id(touch_started_while_off) &&
+              horizontal_distance >= 120 && horizontal_distance > (vertical_distance * 3) / 2) {
+            id(photo_source_swipe_triggered) = true;
+            id(slideshow_swipe_suppress_tap_until_ms) = millis() + 700;
+            id(last_short_tap_ms) = 0;
+            id(backlight_hold_timer).stop();
+            if (horizontal_delta < 0) {
+              id(show_slideshow_navigation_feedback).execute(1);
+              id(immich_advance_forward).execute();
+            } else {
+              id(show_slideshow_navigation_feedback).execute(-1);
+              id(immich_show_previous).execute();
+            }
+            return;
+          }
+          if (!id(developer_features_enabled).state) return;
           const int dy = current_y - start_y;
           const int dx = std::abs(current_x - start_x);
           if (start_y <= 140 && dy >= 110 && dx <= 220) {

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -292,7 +292,10 @@ touchscreen:
             if (horizontal_delta < 0) {
               id(show_slideshow_navigation_feedback).execute(1);
               id(immich_advance_forward).execute();
-            } else if (any_slot_fetch_in_flight(id(espframe_core).slideshow().state().slot_flags)) {
+            } else if (id(espframe_core).slideshow().previous_navigation_blocked(
+                         id(espframe_core).slideshow().state().active_slot,
+                         id(espframe_core).slideshow().state().portrait,
+                         id(espframe_core).slideshow().state().slot_flags)) {
               id(show_slideshow_navigation_feedback).execute(0);
             } else {
               id(show_slideshow_navigation_feedback).execute(-1);

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -311,6 +311,7 @@ touchscreen:
       - lambda: |-
           if (id(photo_source_swipe_triggered)) {
             id(slideshow_swipe_suppress_tap_until_ms) = millis() + 250;
+            id(clear_slideshow_swipe_tap_suppression).execute();
           }
           id(photo_source_swipe_triggered) = false;
           id(photo_source_menu_touch_handled) = false;

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -303,7 +303,7 @@ lvgl:
                   x: 14
                   text: $icon_chevron_left
                   text_color: 0xFFFFFF
-                  text_font: icon_font_setup
+                  text_font: icon_font_navigation
                   hidden: true
               - label:
                   id: slideshow_navigation_feedback_right_icon
@@ -311,7 +311,7 @@ lvgl:
                   x: -14
                   text: $icon_chevron_right
                   text_color: 0xFFFFFF
-                  text_font: icon_font_setup
+                  text_font: icon_font_navigation
         - obj:
             id: connection_failed_overlay
             align: CENTER

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -564,7 +564,7 @@ script:
             lv_obj_add_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_LEFT_MID, 36, 0);
           } else {
-            lv_label_set_text(id(slideshow_navigation_feedback_label), "Please wait");
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "Loading");
             lv_obj_align(id(slideshow_navigation_feedback_label), LV_ALIGN_CENTER, 0, 0);
             lv_obj_add_flag(id(slideshow_navigation_feedback_left_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -533,15 +533,17 @@ script:
           if (direction > 0) {
             lv_label_set_text(id(slideshow_navigation_feedback_label), "Next  >");
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_RIGHT_MID, -36, 0);
-          } else {
+          } else if (direction < 0) {
             lv_label_set_text(id(slideshow_navigation_feedback_label), "<  Previous");
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_LEFT_MID, 36, 0);
+          } else {
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "Please wait");
+            lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_CENTER, 0, 0);
           }
           lv_obj_clear_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);
       - delay: 650ms
       - lambda: |-
           lv_obj_add_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);
-          id(slideshow_swipe_suppress_tap_until_ms) = 0;
 
   - id: slideshow_on_press
     mode: single

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -279,36 +279,39 @@ lvgl:
             id: slideshow_navigation_feedback
             align: RIGHT_MID
             x: -36
-            width: 230
+            width: SIZE_CONTENT
             height: 82
             radius: 41
             bg_color: 0x000000
             bg_opa: 65%
             border_width: 0
-            pad_all: 0
+            pad_left: 16
+            pad_right: 16
+            pad_top: 0
+            pad_bottom: 0
             scrollable: false
             clickable: false
             hidden: true
+            layout:
+              type: flex
+              flex_flow: ROW
+              flex_align_main: CENTER
+              flex_align_cross: CENTER
+              pad_column: 0
             widgets:
               - label:
-                  id: slideshow_navigation_feedback_label
-                  align: CENTER
-                  x: -20
-                  text: "Next"
-                  text_color: 0xFFFFFF
-                  text_font: noto_400_30_font
-              - label:
                   id: slideshow_navigation_feedback_left_icon
-                  align: LEFT_MID
-                  x: 14
                   text: $icon_chevron_left
                   text_color: 0xFFFFFF
                   text_font: icon_font_navigation
                   hidden: true
               - label:
+                  id: slideshow_navigation_feedback_label
+                  text: "Next"
+                  text_color: 0xFFFFFF
+                  text_font: noto_400_30_font
+              - label:
                   id: slideshow_navigation_feedback_right_icon
-                  align: RIGHT_MID
-                  x: -14
                   text: $icon_chevron_right
                   text_color: 0xFFFFFF
                   text_font: icon_font_navigation
@@ -551,26 +554,28 @@ script:
       direction: int
     then:
       - lambda: |-
+          lv_align_t feedback_align = LV_ALIGN_CENTER;
+          int32_t feedback_x = 0;
           if (direction > 0) {
             lv_label_set_text(id(slideshow_navigation_feedback_label), "Next");
-            lv_obj_align(id(slideshow_navigation_feedback_label), LV_ALIGN_CENTER, -20, 0);
             lv_obj_add_flag(id(slideshow_navigation_feedback_left_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_clear_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);
-            lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_RIGHT_MID, -36, 0);
+            feedback_align = LV_ALIGN_RIGHT_MID;
+            feedback_x = -36;
           } else if (direction < 0) {
             lv_label_set_text(id(slideshow_navigation_feedback_label), "Previous");
-            lv_obj_align(id(slideshow_navigation_feedback_label), LV_ALIGN_CENTER, 20, 0);
             lv_obj_clear_flag(id(slideshow_navigation_feedback_left_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);
-            lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_LEFT_MID, 36, 0);
+            feedback_align = LV_ALIGN_LEFT_MID;
+            feedback_x = 36;
           } else {
             lv_label_set_text(id(slideshow_navigation_feedback_label), "Loading");
-            lv_obj_align(id(slideshow_navigation_feedback_label), LV_ALIGN_CENTER, 0, 0);
             lv_obj_add_flag(id(slideshow_navigation_feedback_left_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);
-            lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_CENTER, 0, 0);
           }
           lv_obj_clear_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);
+          lv_obj_update_layout(id(slideshow_navigation_feedback));
+          lv_obj_align(id(slideshow_navigation_feedback), feedback_align, feedback_x, 0);
       - delay: 650ms
       - lambda: |-
           lv_obj_add_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -276,6 +276,29 @@ lvgl:
                               text_color: 0xFFFFFF
                               text_font: noto_400_28_font
         - obj:
+            id: slideshow_navigation_feedback
+            align: RIGHT_MID
+            x: -36
+            width: 230
+            height: 82
+            radius: 41
+            bg_color: 0x000000
+            bg_opa: 65%
+            border_width: 2
+            border_color: 0xFFFFFF
+            border_opa: 35%
+            pad_all: 0
+            scrollable: false
+            clickable: false
+            hidden: true
+            widgets:
+              - label:
+                  id: slideshow_navigation_feedback_label
+                  align: CENTER
+                  text: "Next  >"
+                  text_color: 0xFFFFFF
+                  text_font: noto_400_30_font
+        - obj:
             id: connection_failed_overlay
             align: CENTER
             width: ${display_width}
@@ -501,6 +524,25 @@ lvgl:
 # =============================================================================
 
 script:
+  - id: show_slideshow_navigation_feedback
+    mode: restart
+    parameters:
+      direction: int
+    then:
+      - lambda: |-
+          if (direction > 0) {
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "Next  >");
+            lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_RIGHT_MID, -36, 0);
+          } else {
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "<  Previous");
+            lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_LEFT_MID, 36, 0);
+          }
+          lv_obj_clear_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);
+      - delay: 650ms
+      - lambda: |-
+          lv_obj_add_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);
+          id(slideshow_swipe_suppress_tap_until_ms) = 0;
+
   - id: slideshow_on_press
     mode: single
     then:
@@ -518,7 +560,10 @@ script:
     then:
       - if:
           condition:
-            lambda: 'return !id(touch_started_while_off);'
+            lambda: |-
+              return !id(touch_started_while_off) &&
+                     (id(slideshow_swipe_suppress_tap_until_ms) == 0 ||
+                      (int32_t) (millis() - id(slideshow_swipe_suppress_tap_until_ms)) >= 0);
           then:
             - lambda: |-
                 uint32_t now = millis();

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -284,9 +284,7 @@ lvgl:
             radius: 41
             bg_color: 0x000000
             bg_opa: 65%
-            border_width: 2
-            border_color: 0xFFFFFF
-            border_opa: 35%
+            border_width: 0
             pad_all: 0
             scrollable: false
             clickable: false

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -524,6 +524,13 @@ lvgl:
 # =============================================================================
 
 script:
+  - id: clear_slideshow_swipe_tap_suppression
+    mode: restart
+    then:
+      - delay: 250ms
+      - lambda: |-
+          id(slideshow_swipe_suppress_tap_until_ms) = 0;
+
   - id: show_slideshow_navigation_feedback
     mode: restart
     parameters:
@@ -564,8 +571,7 @@ script:
           condition:
             lambda: |-
               return !id(touch_started_while_off) &&
-                     (id(slideshow_swipe_suppress_tap_until_ms) == 0 ||
-                      (int32_t) (millis() - id(slideshow_swipe_suppress_tap_until_ms)) >= 0);
+                     id(slideshow_swipe_suppress_tap_until_ms) == 0;
           then:
             - lambda: |-
                 uint32_t now = millis();

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -295,9 +295,25 @@ lvgl:
               - label:
                   id: slideshow_navigation_feedback_label
                   align: CENTER
-                  text: "Next  >"
+                  x: -20
+                  text: "Next"
                   text_color: 0xFFFFFF
                   text_font: noto_400_30_font
+              - label:
+                  id: slideshow_navigation_feedback_left_icon
+                  align: LEFT_MID
+                  x: 14
+                  text: $icon_chevron_left
+                  text_color: 0xFFFFFF
+                  text_font: icon_font_setup
+                  hidden: true
+              - label:
+                  id: slideshow_navigation_feedback_right_icon
+                  align: RIGHT_MID
+                  x: -14
+                  text: $icon_chevron_right
+                  text_color: 0xFFFFFF
+                  text_font: icon_font_setup
         - obj:
             id: connection_failed_overlay
             align: CENTER
@@ -538,13 +554,22 @@ script:
     then:
       - lambda: |-
           if (direction > 0) {
-            lv_label_set_text(id(slideshow_navigation_feedback_label), "Next  >");
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "Next");
+            lv_obj_align(id(slideshow_navigation_feedback_label), LV_ALIGN_CENTER, -20, 0);
+            lv_obj_add_flag(id(slideshow_navigation_feedback_left_icon), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_RIGHT_MID, -36, 0);
           } else if (direction < 0) {
-            lv_label_set_text(id(slideshow_navigation_feedback_label), "<  Previous");
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "Previous");
+            lv_obj_align(id(slideshow_navigation_feedback_label), LV_ALIGN_CENTER, 20, 0);
+            lv_obj_clear_flag(id(slideshow_navigation_feedback_left_icon), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_LEFT_MID, 36, 0);
           } else {
             lv_label_set_text(id(slideshow_navigation_feedback_label), "Please wait");
+            lv_obj_align(id(slideshow_navigation_feedback_label), LV_ALIGN_CENTER, 0, 0);
+            lv_obj_add_flag(id(slideshow_navigation_feedback_left_icon), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(id(slideshow_navigation_feedback_right_icon), LV_OBJ_FLAG_HIDDEN);
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_CENTER, 0, 0);
           }
           lv_obj_clear_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -114,7 +114,7 @@ A useful manual pass is:
 - run the manual **PR Validation** workflow for the branch and flash the downloaded firmware artifact to a test display
 - confirm WiFi setup and Immich setup still work
 - confirm the slideshow starts and advances photos
-- check touch wake, sleep, and next-photo gestures
+- check touch wake, sleep, next-photo, previous-image-set, and next-image-set gestures, including the on-screen feedback
 - open the device web UI and change a setting
 - export a backup, restore it, and confirm important settings survive
 - check firmware update status if release/update behavior changed

--- a/docs/touch-controls.md
+++ b/docs/touch-controls.md
@@ -1,11 +1,11 @@
 ---
 title: Espframe Touch Controls
-description: Use Espframe touchscreen gestures to wake the display, put the screen to sleep, and advance the Immich slideshow.
+description: Use Espframe touchscreen gestures to wake the display, put the screen to sleep, and move through the Immich slideshow.
 ---
 
 # Espframe Touch Controls
 
-On the slideshow screen you can wake the display, turn it off with a timed hold, and advance to the next photo.
+On the slideshow screen you can wake the display, turn it off with a timed hold, and move forward or backward through image sets. A brief label appears at the triggered edge after each swipe so you know the gesture was recognized.
 
 ## Gestures
 
@@ -14,3 +14,5 @@ On the slideshow screen you can wake the display, turn it off with a timed hold,
 | **Wake** | Tap the screen when it's off. |
 | **Sleep** | Press and hold for 3 seconds, then release. |
 | **Next photo** | Double-tap on the photo. |
+| **Next image set** | Swipe left across the photo. |
+| **Previous image set** | Swipe right across the photo. |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,7 +69,7 @@ Display behavior is configured from the frame web UI:
 
 - Use [screen brightness and display settings](/screen-settings) for brightness, schedules, and rotation.
 - Use [screen tone and night warmth](/screen-tone) if the panel looks too blue or too warm.
-- Use [touch controls](/touch-controls) if you need wake, sleep, or next-photo gestures.
+- Use [touch controls](/touch-controls) if you need wake, sleep, or next-photo gestures, including left/right image-set navigation.
 
 ## Manual ESPHome Builds
 

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -326,6 +326,14 @@
     {
       "action": "Next photo",
       "gesture": "Double-tap on the photo"
+    },
+    {
+      "action": "Next image set",
+      "gesture": "Swipe left across the photo"
+    },
+    {
+      "action": "Previous image set",
+      "gesture": "Swipe right across the photo"
     }
   ],
   "screen_brightness_day_night_source": "sunrise/sunset",

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -327,6 +327,14 @@
       {
         "action": "Next photo",
         "gesture": "Double-tap on the photo"
+      },
+      {
+        "action": "Next image set",
+        "gesture": "Swipe left across the photo"
+      },
+      {
+        "action": "Previous image set",
+        "gesture": "Swipe right across the photo"
       }
     ],
     "screen_brightness_day_night_source": "sunrise/sunset",

--- a/scripts/product_contract/screen_features.py
+++ b/scripts/product_contract/screen_features.py
@@ -53,7 +53,13 @@ def check_touch_controls_metadata(product: dict, errors: list[str]) -> None:
         ("devices/guition-esp32-p4-jc8012p4a1/device/device.yaml", original_device_yaml),
         ("devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml", v2_device_yaml),
     ):
-        for needle in ("horizontal_distance >= 120", "immich_advance_forward", "immich_show_previous"):
+        for needle in (
+            "horizontal_distance >= 120",
+            "immich_advance_forward",
+            "immich_show_previous",
+            "any_slot_fetch_in_flight",
+            "millis() + 250",
+        ):
             require_contains(device_yaml, needle, path, errors)
     for needle in ("3-second hold timer", "delay: 3s", "screen_schedule_manual_sleep"):
         require_contains(backlight_schedule_yaml, needle, "common/addon/backlight_schedule.yaml", errors)

--- a/scripts/product_contract/screen_features.py
+++ b/scripts/product_contract/screen_features.py
@@ -61,7 +61,7 @@ def check_touch_controls_metadata(product: dict, errors: list[str]) -> None:
             "horizontal_distance >= 120",
             "immich_advance_forward",
             "immich_show_previous",
-            "any_slot_fetch_in_flight",
+            "previous_navigation_blocked",
             "millis() + 250",
             "clear_slideshow_swipe_tap_suppression",
         ):

--- a/scripts/product_contract/screen_features.py
+++ b/scripts/product_contract/screen_features.py
@@ -24,6 +24,8 @@ def check_touch_controls_metadata(product: dict, errors: list[str]) -> None:
     troubleshooting_docs = read(ROOT / "docs" / "troubleshooting.md", errors)
     screen_settings_docs = read(ROOT / "docs" / "screen-settings.md", errors)
     slideshow_yaml = read(ROOT / "devices" / "guition-esp32-p4-jc8012p4a1" / "device" / "screen_slideshow.yaml", errors)
+    original_device_yaml = read(ROOT / "devices" / "guition-esp32-p4-jc8012p4a1" / "device" / "device.yaml", errors)
+    v2_device_yaml = read(ROOT / "devices" / "guition-esp32-p4-jc8012p4a1-v2" / "device" / "device.yaml", errors)
     backlight_schedule_yaml = read(ROOT / "common" / "addon" / "backlight_schedule.yaml", errors)
     backlight_yaml = read(ROOT / "common" / "addon" / "backlight.yaml", errors)
 
@@ -45,6 +47,14 @@ def check_touch_controls_metadata(product: dict, errors: list[str]) -> None:
     require_contains(screen_settings_docs, "same sleep/wake behavior as the touchscreen controls", "docs/screen-settings.md", errors)
     for needle in ("slideshow_on_press", "slideshow_on_short_click", "last_short_tap_ms", "immich_advance_forward"):
         require_contains(slideshow_yaml, needle, "devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml", errors)
+    for needle in ("slideshow_navigation_feedback", "show_slideshow_navigation_feedback"):
+        require_contains(slideshow_yaml, needle, "devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml", errors)
+    for path, device_yaml in (
+        ("devices/guition-esp32-p4-jc8012p4a1/device/device.yaml", original_device_yaml),
+        ("devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml", v2_device_yaml),
+    ):
+        for needle in ("horizontal_distance >= 120", "immich_advance_forward", "immich_show_previous"):
+            require_contains(device_yaml, needle, path, errors)
     for needle in ("3-second hold timer", "delay: 3s", "screen_schedule_manual_sleep"):
         require_contains(backlight_schedule_yaml, needle, "common/addon/backlight_schedule.yaml", errors)
     for needle in ('name: "Screen: Sleep"', 'name: "Screen: Wake"'):

--- a/scripts/product_contract/screen_features.py
+++ b/scripts/product_contract/screen_features.py
@@ -47,7 +47,11 @@ def check_touch_controls_metadata(product: dict, errors: list[str]) -> None:
     require_contains(screen_settings_docs, "same sleep/wake behavior as the touchscreen controls", "docs/screen-settings.md", errors)
     for needle in ("slideshow_on_press", "slideshow_on_short_click", "last_short_tap_ms", "immich_advance_forward"):
         require_contains(slideshow_yaml, needle, "devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml", errors)
-    for needle in ("slideshow_navigation_feedback", "show_slideshow_navigation_feedback"):
+    for needle in (
+        "slideshow_navigation_feedback",
+        "show_slideshow_navigation_feedback",
+        "clear_slideshow_swipe_tap_suppression",
+    ):
         require_contains(slideshow_yaml, needle, "devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml", errors)
     for path, device_yaml in (
         ("devices/guition-esp32-p4-jc8012p4a1/device/device.yaml", original_device_yaml),
@@ -59,6 +63,7 @@ def check_touch_controls_metadata(product: dict, errors: list[str]) -> None:
             "immich_show_previous",
             "any_slot_fetch_in_flight",
             "millis() + 250",
+            "clear_slideshow_swipe_tap_suppression",
         ):
             require_contains(device_yaml, needle, path, errors)
     for needle in ("3-second hold timer", "delay: 3s", "screen_schedule_manual_sleep"):

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -774,6 +774,7 @@ static void test_slideshow_component_portrait_flow() {
   assert(companion_url.empty());
   assert(search_datetime == no_companion.datetime);
   assert(companion_slot == 0);
+  assert(slideshow.state().portrait_search_in_flight);
   assert(slideshow.pop_command(cmd));
   assert(cmd.kind == SLIDESHOW_COMMAND_DEFER_COMPANION_SEARCH);
 
@@ -940,6 +941,31 @@ static void test_slideshow_component_previous_flow() {
   assert(previous.asset_id == "previous");
   assert(!slideshow.pop_command(cmd));
   flags.fetch_in_flight[1] = false;
+
+  portrait.workflow_busy = true;
+  blocked = slideshow.show_previous(1201, active_slot, displayed, slot0, slot1, slot2,
+                                    current, previous, portrait, flags);
+  assert(!blocked);
+  assert(!slideshow.pop_command(cmd));
+  portrait.workflow_busy = false;
+
+  slideshow.state().companion_target_slot = 2;
+  slideshow.state().portrait_search_generation = 1;
+  slideshow.mark_portrait_search_request_started();
+  blocked = slideshow.show_previous(1202, active_slot, displayed, slot0, slot1, slot2,
+                                    current, previous, portrait, flags);
+  assert(!blocked);
+  assert(!slideshow.pop_command(cmd));
+  slideshow.mark_portrait_search_request_finished();
+
+  slideshow.state().portrait_preload_slot = 2;
+  slideshow.state().portrait_preload_left_ready = true;
+  slideshow.state().portrait_preload_right_ready = true;
+  blocked = slideshow.show_previous(1203, active_slot, displayed, slot0, slot1, slot2,
+                                    current, previous, portrait, flags);
+  assert(!blocked);
+  assert(!slideshow.pop_command(cmd));
+  slideshow.state().portrait_preload_slot = -1;
 
   bool shown = slideshow.show_previous(1234, active_slot, displayed, slot0, slot1, slot2,
                                        current, previous, portrait, flags);
@@ -1192,6 +1218,9 @@ static void test_slideshow_component_paired_only_flow() {
   state.portrait_search_generation = 10;
   slideshow.mark_portrait_search_request_started();
   assert(slideshow.portrait_search_response_is_current());
+  slideshow.mark_portrait_search_request_finished();
+  assert(!slideshow.portrait_search_response_is_current());
+  slideshow.mark_portrait_search_request_started();
   slideshow.reject_portrait_slot(8000, 1);
   assert(!slideshow.portrait_search_response_is_current());
 

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -928,6 +928,18 @@ static void test_slideshow_component_previous_flow() {
   SlotFlags flags;
   int active_slot = 0;
   bool displayed = true;
+  SlideshowCommand cmd;
+
+  flags.fetch_in_flight[1] = true;
+  bool blocked = slideshow.show_previous(1200, active_slot, displayed, slot0, slot1, slot2,
+                                         current, previous, portrait, flags);
+  assert(!blocked);
+  assert(active_slot == 0);
+  assert(displayed);
+  assert(current.asset_id == "current");
+  assert(previous.asset_id == "previous");
+  assert(!slideshow.pop_command(cmd));
+  flags.fetch_in_flight[1] = false;
 
   bool shown = slideshow.show_previous(1234, active_slot, displayed, slot0, slot1, slot2,
                                        current, previous, portrait, flags);
@@ -940,7 +952,6 @@ static void test_slideshow_component_previous_flow() {
   assert(slot2.datetime == "2026-04-20T10:00:00");
   assert(slot2.companion_url == "https://example.test/previous-companion");
   assert(flags.fetch_in_flight[2]);
-  SlideshowCommand cmd;
   assert(slideshow.pop_command(cmd));
   assert(cmd.kind == SLIDESHOW_COMMAND_LOAD_PREVIOUS_SLOT);
   assert(cmd.slot == 2);

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -960,16 +960,19 @@ static void test_slideshow_component_previous_flow() {
 
   slideshow.state().portrait_preload_slot = 2;
   slideshow.state().portrait_preload_left_ready = true;
-  slideshow.state().portrait_preload_right_ready = true;
+  slideshow.state().portrait_preload_right_ready = false;
   blocked = slideshow.show_previous(1203, active_slot, displayed, slot0, slot1, slot2,
                                     current, previous, portrait, flags);
   assert(!blocked);
   assert(!slideshow.pop_command(cmd));
-  slideshow.state().portrait_preload_slot = -1;
+  slideshow.state().portrait_preload_right_ready = true;
 
   bool shown = slideshow.show_previous(1234, active_slot, displayed, slot0, slot1, slot2,
                                        current, previous, portrait, flags);
   assert(shown);
+  assert(slideshow.state().portrait_preload_slot == -1);
+  assert(!slideshow.state().portrait_preload_left_ready);
+  assert(!slideshow.state().portrait_preload_right_ready);
   assert(active_slot == 2);
   assert(!displayed);
   assert(current.asset_id == "previous");

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -838,11 +838,33 @@ static void test_slideshow_component_preload_flow() {
   assert(noncritical_count == 0);
 
   std::string reason;
+  int preload_slot = 1;
+  left_ready = true;
+  right_ready = true;
   preload_in_flight = true;
   noncritical_count = 1;
-  slideshow.on_preload_left_error(reason, left_ready, preload_in_flight, noncritical_count);
+  slideshow.on_preload_left_error(reason, preload_slot, left_ready, right_ready,
+                                  preload_in_flight, noncritical_count);
   assert(reason == "portrait preload left error");
+  assert(preload_slot == -1);
   assert(!left_ready);
+  assert(!right_ready);
+  assert(!preload_in_flight);
+  assert(noncritical_count == 0);
+  assert(slideshow.pop_command(cmd));
+  assert(cmd.kind == SLIDESHOW_COMMAND_LOG_DIAG);
+
+  preload_slot = 1;
+  left_ready = true;
+  right_ready = true;
+  preload_in_flight = true;
+  noncritical_count = 1;
+  slideshow.on_preload_right_error(reason, preload_slot, left_ready, right_ready,
+                                   preload_in_flight, noncritical_count);
+  assert(reason == "portrait preload right error");
+  assert(preload_slot == -1);
+  assert(!left_ready);
+  assert(!right_ready);
   assert(!preload_in_flight);
   assert(noncritical_count == 0);
   assert(slideshow.pop_command(cmd));


### PR DESCRIPTION
## What changes when merged

- Add horizontal swipe gestures for next and previous image-set navigation.
- Show edge-aligned navigation feedback using dedicated 56 px Material Design chevron icons instead of literal `<` and `>` glyphs.
- Render the Next/Previous feedback pill without a visible outline.
- Size each navigation feedback pill to its visible text and chevron content.
- Show “Loading” instead of “Please wait” when navigation is temporarily blocked.
- Suppress navigation on wake touches, menus, and error overlays, and prevent swipe releases from counting as double taps.
- Serialize backward navigation with slot and portrait-preload work, including clearing failed preload state so navigation cannot remain blocked.
- Document the controls and cover both display revisions plus preload failure behavior.

## Automated checks

- [x] `npm run check:pr` passed
- [x] CI checks are expected to pass

CI has not started because the PR currently conflicts with `main`.

## Device testing

- [ ] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [x] Needs device testing before merge
- [x] Local firmware built from current PR head `5914ee3` flashed over OTA

PR Validation workflow run/artifact: Not available while the PR conflicts with `main`.

Firmware artifact (`firmware-test-<device>`): Local `dev.yaml` build from PR head.

Device tested: Guition ESP32-P4 JC8012P4A1 10.1-inch Immich Frame at `192.168.6.106`.

Result/notes: OTA upload of current head `5914ee3` succeeded and the display returned online after reboot. The smaller chevrons and content-fitted navigation pills are ready for hands-on visual confirmation.

## Notes for reviewers

- All six review threads are resolved.
- Both current factory targets compile with ESPHome 2026.7.4.
- The branch still needs its conflicts with `main` resolved before GitHub CI can run.
