### PR TITLE
Require pull requests for agent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Contribution workflow
+
+When a task changes tracked project files, deliver the work through a GitHub
+pull request unless the user explicitly asks for a different workflow.
+
+- Never commit directly to `main`.
+- Create or use a focused non-default branch for the task.
+- Keep unrelated local changes out of the branch, commits, and pull request.
+- Run the relevant validation, then commit and push the completed changes.
+- Open a pull request against the repository's default branch and include its
+  URL in the final response.
+- Leave the pull request open for review; do not merge it unless the user
+  explicitly asks.
+- If authentication, permissions, missing remotes, or failing required checks
+  prevent creating the pull request, report the blocker clearly and preserve
+  the prepared local work.
+
+Read-only tasks, reviews, investigations, and tasks that do not change tracked
+files do not require an empty pull request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,59 @@
-# Contribution workflow
+# Agent contribution workflow
 
 When a task changes tracked project files, deliver the work through a GitHub
 pull request unless the user explicitly asks for a different workflow.
-
-- Never commit directly to `main`.
-- Create or use a focused non-default branch for the task.
-- Keep unrelated local changes out of the branch, commits, and pull request.
-- Run the relevant validation, then commit and push the completed changes.
-- Open a pull request against the repository's default branch and include its
-  URL in the final response.
-- Leave the pull request open for review; do not merge it unless the user
-  explicitly asks.
-- If authentication, permissions, missing remotes, or failing required checks
-  prevent creating the pull request, report the blocker clearly and preserve
-  the prepared local work.
-
 Read-only tasks, reviews, investigations, and tasks that do not change tracked
 files do not require an empty pull request.
+
+## Before editing
+
+- Inspect the branch and working tree. Never stage, stash, commit, overwrite,
+  or revert unrelated user changes.
+- If the checkout is dirty with unrelated work or is already serving another
+  task, create a separate worktree from the latest `origin/main`.
+- Never commit directly to `main`. Create or use a focused non-default branch
+  for the task and keep unrelated changes out of it.
+- Review `product/source-ownership.json` before changing generated, vendored,
+  or externally sourced files. Edit declared sources and run `npm run generate`
+  instead of hand-editing generated outputs. Change vendored code only when the
+  task requires it, preserving its attribution and revision metadata.
+
+## Implementation requirements
+
+- Keep the change focused. Do not add opportunistic refactors, dependency
+  upgrades, formatting sweeps, or unrelated documentation changes.
+- Unless the user explicitly approves a breaking change and migration plan,
+  preserve ESPHome and Home Assistant entity names, saved preferences,
+  configuration defaults and fields, backup compatibility, public web
+  endpoints, and existing device support.
+- Add or update regression coverage for changed behavior when practical. Use
+  compatibility fixtures for settings and backups, host-side C++ tests for
+  firmware decisions, and browser/module tests for web behavior.
+- Split large work into independently reviewable stages that preserve existing
+  behavior between pull requests.
+
+## Validation
+
+- Follow `docs/testing.md` and run `npm run check:pr` before opening or updating
+  the pull request.
+- For ESPHome YAML changes or C++ changes not covered by host-side tests, run the
+  relevant full firmware compile. If compile or hardware validation is not
+  available, say so and mark the pull request as needing that validation.
+- Never claim a check, compile, device test, or manual test passed unless it was
+  actually run. Report exact failures and distinguish pre-existing failures
+  from failures caused by the change.
+
+## Delivery and authorization
+
+- Commit and push the completed changes, then open a pull request against the
+  repository's default branch. Include its URL in the final response.
+- Complete `.github/pull_request_template.md` with the user-visible result,
+  checks actually run, device-testing status, known limitations, and relevant
+  follow-up work.
+- Monitor the initial CI result and fix failures caused by the pull request.
+- Leave the pull request open for review. Do not merge pull requests, create
+  releases or tags, deploy documentation, flash devices, change repository
+  settings, or trigger destructive workflows unless the user explicitly asks.
+- If authentication, permissions, missing remotes, failing required checks, or
+  other blockers prevent delivery, report the blocker clearly and preserve the
+  prepared local work.


### PR DESCRIPTION
## What changes when merged

- Agents must isolate work from unrelated changes and use focused pull requests.
- Agents must respect generated/vendored source ownership and compatibility contracts.
- Agents must add relevant tests, run documented validation, report exact gaps, and monitor CI.
- Merges, releases, tags, deployments, device flashing, repository-setting changes, and destructive workflows still require explicit user authorization.

## Automated checks

- [ ] `npm run check:pr` passed
- [x] CI checks are expected to pass

Local validation passed through generated files, product/backup/compatibility/ownership/budget/firmware-field checks, TypeScript, web compatibility/modules/CLI, package/product/workflow/release/budget tests, firmware helper tests, and the docs build.

The full local gate could not complete because Chrome/Chromium is unavailable for browser smoke tests and the host timezone database lacks `Asia/Rangoon`. CI provides the authoritative clean-environment result.

## Device testing

- [x] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [ ] Needs device testing before merge

PR Validation workflow run/artifact: Not needed

Firmware artifact (`firmware-test-<device>`): Not needed

Device tested: Not needed

Result/notes: Documentation-only agent policy change.

## Notes for reviewers

- The policy intentionally references `docs/testing.md` and `product/source-ownership.json` instead of duplicating their detailed rules.
- Read-only work remains exempt from empty pull requests.