### PR TITLE
Migrate trusted CI jobs to the Espframe runner

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     name: Validate PR Gate
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -109,6 +109,29 @@ jobs:
           set -euo pipefail
           TEST_VERSION="pr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p output
+          image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
+          workspace_volume="espframe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.slug }}"
+          staging_container=""
+
+          cleanup_workspace() {
+            if [ -n "${staging_container}" ]; then
+              docker rm -f "${staging_container}" >/dev/null 2>&1 || true
+            fi
+            docker volume rm -f "${workspace_volume}" >/dev/null 2>&1 || true
+          }
+          trap cleanup_workspace EXIT
+
+          docker volume create "${workspace_volume}" >/dev/null
+          staging_container=$(docker create \
+            --user "$(id -u):$(id -g)" \
+            --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
+            --entrypoint /bin/true \
+            "${image}")
+          docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"
+          docker rm "${staging_container}" >/dev/null
+          staging_container=""
+          rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"
+          mkdir -p "${RELEASE_ESPHOME_CACHE_DIR}"
 
           compile_in_isolated_container() {
             local config_file="$1"
@@ -116,12 +139,12 @@ jobs:
             local binary_name="$3"
             local log_file="output/${{ matrix.slug }}.${profile}.log"
             local output_binary="output/${{ matrix.slug }}.${profile}.bin"
-            local image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
             local container
             container=$(docker create \
               --user "$(id -u):$(id -g)" \
               -e HOME="${ESPHOME_CONFIG_MOUNT}" \
               -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false \
+              --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
               "${image}" \
               -s firmware_version "${TEST_VERSION}" \
               compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}")
@@ -131,7 +154,6 @@ jobs:
             }
             trap cleanup_container RETURN
 
-            docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"
             set +e
             docker start -a "${container}" 2>&1 | tee "${log_file}"
             local status=${PIPESTATUS[0]}
@@ -146,10 +168,6 @@ jobs:
               return 1
             fi
 
-            rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"
-            mkdir -p "${RELEASE_ESPHOME_CACHE_DIR}"
-            docker cp "${container}:${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/." \
-              "${RELEASE_ESPHOME_CACHE_DIR}"
           }
 
           compile_in_isolated_container \
@@ -165,6 +183,15 @@ jobs:
             --compile-log "output/${{ matrix.slug }}.ota.log" \
             --profile ota \
             --binary "output/${{ matrix.slug }}.ota.bin"
+
+          staging_container=$(docker create \
+            --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
+            --entrypoint /bin/true \
+            "${image}")
+          docker cp "${staging_container}:${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/." \
+            "${RELEASE_ESPHOME_CACHE_DIR}"
+          docker rm "${staging_container}" >/dev/null
+          staging_container=""
 
           {
             echo "version=${TEST_VERSION}"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -92,9 +92,21 @@ jobs:
       RELEASE_ESPHOME_CACHE_KEY_PREFIX: ${{ needs.firmware-metadata.outputs.release_esphome_cache_key_prefix }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix: ${{ fromJson(needs.firmware-metadata.outputs.release_matrix) }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Reclaim runner Docker storage
+        run: |
+          set -euo pipefail
+          docker system df || true
+          docker container prune -f
+          docker image prune -af
+          docker builder prune -af --keep-storage 2GB
+          docker volume prune -f
+          docker pull "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
+          docker system df
 
       - name: Cache ESPHome build
         uses: actions/cache@v6

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -104,7 +104,7 @@ jobs:
           docker container prune -f
           docker image prune -af
           docker builder prune -af --keep-storage 2GB
-          docker volume prune -f
+          docker volume prune --all --force
           docker pull "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
           docker system df
 
@@ -139,7 +139,7 @@ jobs:
             --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
             --entrypoint /bin/true \
             "${image}")
-          docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"
+          docker cp --archive "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"
           docker rm "${staging_container}" >/dev/null
           staging_container=""
           rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,6 +2,10 @@ name: PR Validation
 
 on:
   pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 3 * * 0'
   workflow_dispatch:
 
 permissions:
@@ -17,7 +21,8 @@ concurrency:
 jobs:
   validate:
     name: Validate PR Gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe' }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -25,6 +30,18 @@ jobs:
         with:
           node-version: 24
           cache: npm
+
+      - name: Install pinned timezone data
+        shell: bash
+        run: |
+          TZDATA_VENV="${RUNNER_TEMP}/espframe-tzdata"
+          python3 -m venv "${TZDATA_VENV}"
+          "${TZDATA_VENV}/bin/python" -m pip install \
+            --disable-pip-version-check \
+            "tzdata==2026.3"
+          TZDATA_SITE="$("${TZDATA_VENV}/bin/python" -c 'import site; print(site.getsitepackages()[0])')"
+          echo "PYTHONPATH=${TZDATA_SITE}${PYTHONPATH:+:${PYTHONPATH}}" >> "${GITHUB_ENV}"
+          echo "PYTHONTZPATH=${TZDATA_SITE}/tzdata/zoneinfo" >> "${GITHUB_ENV}"
 
       - name: Install dependencies
         run: npm ci
@@ -34,8 +51,9 @@ jobs:
 
   firmware-metadata:
     name: Read Firmware Build Metadata
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: espframe
+    timeout-minutes: 5
     outputs:
       release_matrix: ${{ steps.product.outputs.release_matrix }}
       esphome_docker_image: ${{ steps.product.outputs.esphome_docker_image }}
@@ -61,8 +79,8 @@ jobs:
 
   compile:
     name: Compile Firmware
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: espframe
     needs: [validate, firmware-metadata]
     timeout-minutes: 30
     env:
@@ -88,43 +106,65 @@ jobs:
 
       - name: Compile test firmware artifacts
         run: |
+          set -euo pipefail
           TEST_VERSION="pr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p output
 
-          docker run ${ESPHOME_DOCKER_REMOVE_FLAG} \
-            -v "${PWD}:${ESPHOME_CONFIG_MOUNT}" \
-            "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}" \
-            -s firmware_version "${TEST_VERSION}" \
-            compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml" \
-            2>&1 | tee "output/${{ matrix.slug }}.factory.log"
+          compile_in_isolated_container() {
+            local config_file="$1"
+            local profile="$2"
+            local binary_name="$3"
+            local log_file="output/${{ matrix.slug }}.${profile}.log"
+            local output_binary="output/${{ matrix.slug }}.${profile}.bin"
+            local image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
+            local container
+            container=$(docker create \
+              --user "$(id -u):$(id -g)" \
+              -e HOME="${ESPHOME_CONFIG_MOUNT}" \
+              -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false \
+              "${image}" \
+              -s firmware_version "${TEST_VERSION}" \
+              compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}")
 
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
-          if [ ! -f "${BUILD_DIR}/firmware.factory.bin" ]; then
-            echo "::error::Firmware compilation failed - factory binary not found"
-            exit 1
-          fi
-          sudo cp "${BUILD_DIR}/firmware.factory.bin" "output/${{ matrix.slug }}.factory.bin"
+            cleanup_container() {
+              docker rm -f "${container}" >/dev/null 2>&1 || true
+            }
+            trap cleanup_container RETURN
+
+            docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"
+            set +e
+            docker start -a "${container}" 2>&1 | tee "${log_file}"
+            local status=${PIPESTATUS[0]}
+            set -e
+            if [ "${status}" -ne 0 ]; then
+              return "${status}"
+            fi
+
+            local container_build_dir="${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
+            if ! docker cp "${container}:${container_build_dir}/${binary_name}" "${output_binary}"; then
+              echo "::error::Firmware compilation failed - ${binary_name} not found"
+              return 1
+            fi
+
+            rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"
+            mkdir -p "${RELEASE_ESPHOME_CACHE_DIR}"
+            docker cp "${container}:${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/." \
+              "${RELEASE_ESPHOME_CACHE_DIR}"
+          }
+
+          compile_in_isolated_container \
+            "${{ matrix.yaml }}.factory.yaml" factory firmware.factory.bin
           python3 scripts/check_build_budgets.py \
             --compile-log "output/${{ matrix.slug }}.factory.log" \
             --profile factory \
-            --binary "${BUILD_DIR}/firmware.factory.bin"
+            --binary "output/${{ matrix.slug }}.factory.bin"
 
-          docker run ${ESPHOME_DOCKER_REMOVE_FLAG} \
-            -v "${PWD}:${ESPHOME_CONFIG_MOUNT}" \
-            "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}" \
-            -s firmware_version "${TEST_VERSION}" \
-            compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml" \
-            2>&1 | tee "output/${{ matrix.slug }}.ota.log"
-
-          if [ ! -f "${BUILD_DIR}/firmware.ota.bin" ]; then
-            echo "::error::Firmware compilation failed - OTA binary not found"
-            exit 1
-          fi
-          sudo cp "${BUILD_DIR}/firmware.ota.bin" "output/${{ matrix.slug }}.ota.bin"
+          compile_in_isolated_container \
+            "${{ matrix.yaml }}.yaml" ota firmware.ota.bin
           python3 scripts/check_build_budgets.py \
             --compile-log "output/${{ matrix.slug }}.ota.log" \
             --profile ota \
-            --binary "${BUILD_DIR}/firmware.ota.bin"
+            --binary "output/${{ matrix.slug }}.ota.bin"
 
           {
             echo "version=${TEST_VERSION}"
@@ -136,7 +176,6 @@ jobs:
         if: always()
         run: |
           if [ -d "${RELEASE_ESPHOME_CACHE_DIR}" ]; then
-            sudo chown -R "$USER:$USER" "${RELEASE_ESPHOME_CACHE_DIR}"
             chmod -R u+rwX "${RELEASE_ESPHOME_CACHE_DIR}"
           fi
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,8 @@ jobs:
     if: >-
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: espframe
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -60,7 +61,8 @@ jobs:
     if: >-
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: espframe
+    timeout-minutes: 20
     outputs:
       release_tag: ${{ steps.release-meta.outputs.release_tag }}
     steps:
@@ -263,7 +265,8 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     needs: [build-docs, download-firmware]
-    runs-on: ubuntu-latest
+    runs-on: espframe
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           docker container prune -f
           docker image prune -af
           docker builder prune -af --keep-storage 2GB
-          docker volume prune -f
+          docker volume prune --all --force
           docker pull "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
           docker system df
 
@@ -132,7 +132,7 @@ jobs:
             --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
             --entrypoint /bin/true \
             "${image}")
-          docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"
+          docker cp --archive "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"
           docker rm "${staging_container}" >/dev/null
           staging_container=""
           rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ env:
 jobs:
   release-metadata:
     name: Read Product Release Metadata
-    runs-on: ubuntu-latest
+    runs-on: espframe
+    timeout-minutes: 5
     outputs:
       release_matrix: ${{ steps.product.outputs.release_matrix }}
       device_slugs: ${{ steps.product.outputs.device_slugs }}
@@ -43,7 +44,8 @@ jobs:
   release-notes:
     name: Update Release Notes
     if: github.event_name == 'release'
-    runs-on: ubuntu-latest
+    runs-on: espframe
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:
@@ -65,7 +67,7 @@ jobs:
   build-firmware:
     name: Build ${{ matrix.slug }}
     needs: release-metadata
-    runs-on: ubuntu-latest
+    runs-on: espframe
     timeout-minutes: 30
     env:
       ESPHOME_DOCKER_IMAGE: ${{ needs.release-metadata.outputs.esphome_docker_image }}
@@ -94,50 +96,73 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
+          set -euo pipefail
           python3 scripts/firmware_release.py inject \
             --slug "${{ matrix.slug }}" \
             --version "${VERSION}"
 
           mkdir -p output
 
-          docker run ${ESPHOME_DOCKER_REMOVE_FLAG} \
-            -v "${PWD}:${ESPHOME_CONFIG_MOUNT}" \
-            "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}" \
-            compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml" \
-            2>&1 | tee "output/${{ matrix.slug }}.factory.log"
+          compile_in_isolated_container() {
+            local config_file="$1"
+            local profile="$2"
+            local binary_name="$3"
+            local log_file="output/${{ matrix.slug }}.${profile}.log"
+            local output_binary="output/${{ matrix.slug }}.${profile}.bin"
+            local image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
+            local container
+            container=$(docker create \
+              --user "$(id -u):$(id -g)" \
+              -e HOME="${ESPHOME_CONFIG_MOUNT}" \
+              -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false \
+              "${image}" \
+              -s firmware_version "${VERSION}" \
+              compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}")
 
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
-          if [ ! -f "${BUILD_DIR}/firmware.factory.bin" ]; then
-            echo "::error::Firmware compilation failed - factory binary not found"
-            exit 1
-          fi
-          sudo cp "${BUILD_DIR}/firmware.factory.bin" "output/${{ matrix.slug }}.factory.bin"
+            cleanup_container() {
+              docker rm -f "${container}" >/dev/null 2>&1 || true
+            }
+            trap cleanup_container RETURN
+
+            docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"
+            set +e
+            docker start -a "${container}" 2>&1 | tee "${log_file}"
+            local status=${PIPESTATUS[0]}
+            set -e
+            if [ "${status}" -ne 0 ]; then
+              return "${status}"
+            fi
+
+            local container_build_dir="${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
+            if ! docker cp "${container}:${container_build_dir}/${binary_name}" "${output_binary}"; then
+              echo "::error::Firmware compilation failed - ${binary_name} not found"
+              return 1
+            fi
+
+            rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"
+            mkdir -p "${RELEASE_ESPHOME_CACHE_DIR}"
+            docker cp "${container}:${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/." \
+              "${RELEASE_ESPHOME_CACHE_DIR}"
+          }
+
+          compile_in_isolated_container \
+            "${{ matrix.yaml }}.factory.yaml" factory firmware.factory.bin
           python3 scripts/check_build_budgets.py \
             --compile-log "output/${{ matrix.slug }}.factory.log" \
             --profile factory \
-            --binary "${BUILD_DIR}/firmware.factory.bin"
+            --binary "output/${{ matrix.slug }}.factory.bin"
 
-          docker run ${ESPHOME_DOCKER_REMOVE_FLAG} \
-            -v "${PWD}:${ESPHOME_CONFIG_MOUNT}" \
-            "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}" \
-            -s firmware_version "${VERSION}" \
-            compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml" \
-            2>&1 | tee "output/${{ matrix.slug }}.ota.log"
-
-          if [ ! -f "${BUILD_DIR}/firmware.ota.bin" ]; then
-            echo "::error::Firmware compilation failed - OTA binary not found"
-            exit 1
-          fi
+          compile_in_isolated_container \
+            "${{ matrix.yaml }}.yaml" ota firmware.ota.bin
           python3 scripts/check_build_budgets.py \
             --compile-log "output/${{ matrix.slug }}.ota.log" \
             --profile ota \
-            --binary "${BUILD_DIR}/firmware.ota.bin"
+            --binary "output/${{ matrix.slug }}.ota.bin"
 
       - name: Fix ESPHome cache permissions
         if: always()
         run: |
           if [ -d "${RELEASE_ESPHOME_CACHE_DIR}" ]; then
-            sudo chown -R "$USER:$USER" "${RELEASE_ESPHOME_CACHE_DIR}"
             chmod -R u+rwX "${RELEASE_ESPHOME_CACHE_DIR}"
           fi
 
@@ -145,15 +170,12 @@ jobs:
         env:
           VERSION: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
-          BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"
           mkdir -p output
 
-          if [ ! -f "${BUILD_DIR}/firmware.ota.bin" ]; then
+          if [ ! -f "output/${{ matrix.slug }}.ota.bin" ]; then
             echo "::error::Firmware compilation failed - OTA binary not found"
             exit 1
           fi
-
-          sudo cp "${BUILD_DIR}/firmware.ota.bin" "output/${{ matrix.slug }}.ota.bin"
 
           python3 scripts/firmware_release.py manifest \
             --slug "${{ matrix.slug }}" \
@@ -180,7 +202,8 @@ jobs:
     name: Publish to Release
     if: github.event_name == 'release'
     needs: [build-firmware, release-metadata]
-    runs-on: ubuntu-latest
+    runs-on: espframe
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,23 @@ jobs:
       RELEASE_ESPHOME_CACHE_KEY_PREFIX: ${{ needs.release-metadata.outputs.release_esphome_cache_key_prefix }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix: ${{ fromJson(needs.release-metadata.outputs.release_matrix) }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Reclaim runner Docker storage
+        run: |
+          set -euo pipefail
+          docker system df || true
+          docker container prune -f
+          docker image prune -af
+          docker builder prune -af --keep-storage 2GB
+          docker volume prune -f
+          docker pull "${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
+          docker system df
 
       - name: Cache ESPHome build
         uses: actions/cache@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,29 @@ jobs:
             --version "${VERSION}"
 
           mkdir -p output
+          image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
+          workspace_volume="espframe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.slug }}"
+          staging_container=""
+
+          cleanup_workspace() {
+            if [ -n "${staging_container}" ]; then
+              docker rm -f "${staging_container}" >/dev/null 2>&1 || true
+            fi
+            docker volume rm -f "${workspace_volume}" >/dev/null 2>&1 || true
+          }
+          trap cleanup_workspace EXIT
+
+          docker volume create "${workspace_volume}" >/dev/null
+          staging_container=$(docker create \
+            --user "$(id -u):$(id -g)" \
+            --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
+            --entrypoint /bin/true \
+            "${image}")
+          docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"
+          docker rm "${staging_container}" >/dev/null
+          staging_container=""
+          rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"
+          mkdir -p "${RELEASE_ESPHOME_CACHE_DIR}"
 
           compile_in_isolated_container() {
             local config_file="$1"
@@ -109,12 +132,12 @@ jobs:
             local binary_name="$3"
             local log_file="output/${{ matrix.slug }}.${profile}.log"
             local output_binary="output/${{ matrix.slug }}.${profile}.bin"
-            local image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"
             local container
             container=$(docker create \
               --user "$(id -u):$(id -g)" \
               -e HOME="${ESPHOME_CONFIG_MOUNT}" \
               -e PLATFORMIO_SETTING_ENABLE_TELEMETRY=false \
+              --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
               "${image}" \
               -s firmware_version "${VERSION}" \
               compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}")
@@ -124,7 +147,6 @@ jobs:
             }
             trap cleanup_container RETURN
 
-            docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"
             set +e
             docker start -a "${container}" 2>&1 | tee "${log_file}"
             local status=${PIPESTATUS[0]}
@@ -139,10 +161,6 @@ jobs:
               return 1
             fi
 
-            rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"
-            mkdir -p "${RELEASE_ESPHOME_CACHE_DIR}"
-            docker cp "${container}:${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/." \
-              "${RELEASE_ESPHOME_CACHE_DIR}"
           }
 
           compile_in_isolated_container \
@@ -158,6 +176,15 @@ jobs:
             --compile-log "output/${{ matrix.slug }}.ota.log" \
             --profile ota \
             --binary "output/${{ matrix.slug }}.ota.bin"
+
+          staging_container=$(docker create \
+            --mount "type=volume,source=${workspace_volume},target=${ESPHOME_CONFIG_MOUNT}" \
+            --entrypoint /bin/true \
+            "${image}")
+          docker cp "${staging_container}:${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}/." \
+            "${RELEASE_ESPHOME_CACHE_DIR}"
+          docker rm "${staging_container}" >/dev/null
+          staging_container=""
 
       - name: Fix ESPHome cache permissions
         if: always()

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -31,7 +31,7 @@ jobs:
           docker container prune -f
           docker image prune -af
           docker builder prune -af --keep-storage 2GB
-          docker volume prune -f
+          docker volume prune --all --force
 
       - name: Report disk usage after cleanup
         if: always()

--- a/.github/workflows/runner-cleanup.yml
+++ b/.github/workflows/runner-cleanup.yml
@@ -1,0 +1,40 @@
+name: Runner Disk Cleanup
+
+on:
+  schedule:
+    - cron: '47 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: espframe-runner-disk-cleanup
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Reclaim Espframe Runner Disk
+    runs-on: espframe
+    timeout-minutes: 10
+    steps:
+      - name: Report disk usage before cleanup
+        run: |
+          set -euo pipefail
+          df -h "$GITHUB_WORKSPACE" "$HOME" || true
+          docker system df || true
+
+      - name: Reclaim isolated Docker storage
+        run: |
+          set -euo pipefail
+          docker info >/dev/null
+          docker container prune -f
+          docker image prune -af
+          docker builder prune -af --keep-storage 2GB
+          docker volume prune -f
+
+      - name: Report disk usage after cleanup
+        if: always()
+        run: |
+          df -h "$GITHUB_WORKSPACE" "$HOME" || true
+          docker system df || true

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,7 +76,11 @@ This group compiles and runs host-side C++ tests for firmware helper logic, then
 
 ### Full Firmware Compile
 
-Pull requests run the normal validation gate automatically. Full ESPHome firmware builds are slower, so they are available from the **PR Validation** workflow's manual run button. Run that workflow against a feature branch when you need firmware files to test on a device before merging.
+Pull requests run the normal validation gate automatically. Full ESPHome
+firmware builds are slower, so they run weekly on the dedicated Espframe CI
+runner and remain available from the **PR Validation** workflow's manual run
+button. Run that workflow against a feature branch when you need firmware files
+to test on a device before merging.
 
 The manual workflow builds both factory and OTA firmware, enforces the flash,
 RAM, and binary budgets, and uploads a `firmware-test-<device>` artifact containing:

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -1455,7 +1455,6 @@
   "github_actions_node24_env": "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24",
   "github_actions_runner": "ubuntu-latest",
   "github_workflow_job_runners": {
-    "compile.validate": "${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe' }}",
     "compile.firmware-metadata": "espframe",
     "compile.compile": "espframe",
     "docs.build-docs": "espframe",

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -1454,6 +1454,18 @@
   "docs_build_command": "npm run docs:build",
   "github_actions_node24_env": "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24",
   "github_actions_runner": "ubuntu-latest",
+  "github_workflow_job_runners": {
+    "compile.validate": "${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe' }}",
+    "compile.firmware-metadata": "espframe",
+    "compile.compile": "espframe",
+    "docs.build-docs": "espframe",
+    "docs.download-firmware": "espframe",
+    "docs.deploy-docs": "espframe",
+    "release.release-metadata": "espframe",
+    "release.release-notes": "espframe",
+    "release.build-firmware": "espframe",
+    "release.publish": "espframe"
+  },
   "github_cli_env": {
     "GH_TOKEN": "${{ github.token }}",
     "GH_REPO": "${{ github.repository }}"
@@ -1497,6 +1509,8 @@
   "github_workflow_events": {
     "compile": [
       "pull_request",
+      "push",
+      "schedule",
       "workflow_dispatch"
     ],
     "docs": [
@@ -1555,8 +1569,8 @@
   },
   "github_workflow_job_conditions": {
     "compile.validate": null,
-    "compile.firmware-metadata": "github.event_name == 'workflow_dispatch'",
-    "compile.compile": "github.event_name == 'workflow_dispatch'",
+    "compile.firmware-metadata": "github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'",
+    "compile.compile": "github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'",
     "docs.build-docs": "github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'",
     "docs.download-firmware": "github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'",
     "docs.deploy-docs": null,

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1456,7 +1456,6 @@
     "github_actions_node24_env": "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24",
     "github_actions_runner": "ubuntu-latest",
     "github_workflow_job_runners": {
-      "compile.validate": "${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe' }}",
       "compile.firmware-metadata": "espframe",
       "compile.compile": "espframe",
       "docs.build-docs": "espframe",

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1455,6 +1455,18 @@
     "docs_build_command": "npm run docs:build",
     "github_actions_node24_env": "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24",
     "github_actions_runner": "ubuntu-latest",
+    "github_workflow_job_runners": {
+      "compile.validate": "${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe' }}",
+      "compile.firmware-metadata": "espframe",
+      "compile.compile": "espframe",
+      "docs.build-docs": "espframe",
+      "docs.download-firmware": "espframe",
+      "docs.deploy-docs": "espframe",
+      "release.release-metadata": "espframe",
+      "release.release-notes": "espframe",
+      "release.build-firmware": "espframe",
+      "release.publish": "espframe"
+    },
     "github_cli_env": {
       "GH_TOKEN": "${{ github.token }}",
       "GH_REPO": "${{ github.repository }}"
@@ -1498,6 +1510,8 @@
     "github_workflow_events": {
       "compile": [
         "pull_request",
+        "push",
+        "schedule",
         "workflow_dispatch"
       ],
       "docs": [
@@ -1556,8 +1570,8 @@
     },
     "github_workflow_job_conditions": {
       "compile.validate": null,
-      "compile.firmware-metadata": "github.event_name == 'workflow_dispatch'",
-      "compile.compile": "github.event_name == 'workflow_dispatch'",
+      "compile.firmware-metadata": "github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'",
+      "compile.compile": "github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'",
       "docs.build-docs": "github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'",
       "docs.download-firmware": "github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'",
       "docs.deploy-docs": null,

--- a/scripts/product_contract/build_outputs.py
+++ b/scripts/product_contract/build_outputs.py
@@ -169,31 +169,18 @@ def check_factory_firmware_metadata(product: dict, errors: list[str]) -> None:
             require_contains(build_text, f'css_include: "{factory_css_include}"', build_yaml, errors)
         if factory_js_include:
             require_contains(build_text, f'js_include: "{factory_js_include}"', build_yaml, errors)
-        if esphome_config_mount:
-            require_contains(
-                compile_workflow,
-                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml"',
-                ".github/workflows/compile.yml",
-                errors,
-            )
-            require_contains(
-                compile_workflow,
-                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml"',
-                ".github/workflows/compile.yml",
-                errors,
-            )
-            require_contains(
-                release_workflow,
-                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml"',
-                ".github/workflows/release.yml",
-                errors,
-            )
-            require_contains(
-                release_workflow,
-                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml"',
-                ".github/workflows/release.yml",
-                errors,
-            )
+
+    if esphome_config_mount:
+        for workflow, label in (
+            (compile_workflow, ".github/workflows/compile.yml"),
+            (release_workflow, ".github/workflows/release.yml"),
+        ):
+            for fragment in (
+                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}"',
+                '"${{ matrix.yaml }}.factory.yaml" factory firmware.factory.bin',
+                '"${{ matrix.yaml }}.yaml" ota firmware.ota.bin',
+            ):
+                require_contains(workflow, fragment, label, errors)
 
     if network_mode:
         require_contains(install_docs, "hotspot", "docs/install.md", errors)

--- a/scripts/product_contract/project_release_metadata.py
+++ b/scripts/product_contract/project_release_metadata.py
@@ -311,6 +311,23 @@ def check_project_release_metadata(product: dict, errors: list[str]) -> None:
                 if not job_name:
                     errors.append(f"project.github_workflow_jobs.{workflow or '<missing>'}.{job_id or '<missing>'} must be a non-empty string")
     configured_workflow_jobs, jobs_by_workflow = workflow_job_index(workflow_jobs)
+    workflow_job_runners = project.get("github_workflow_job_runners", {})
+    if workflow_job_runners:
+        if not isinstance(workflow_job_runners, dict):
+            errors.append("project.github_workflow_job_runners must be an object")
+        else:
+            for raw_key, raw_runner in workflow_job_runners.items():
+                key = str(raw_key).strip()
+                if key not in configured_workflow_jobs:
+                    errors.append(
+                        f"project.github_workflow_job_runners.{key or '<missing>'} "
+                        "must point at a known workflow job"
+                    )
+                if not isinstance(raw_runner, str) or not raw_runner.strip():
+                    errors.append(
+                        f"project.github_workflow_job_runners.{key or '<missing>'} "
+                        "must be a non-empty string"
+                    )
     workflow_job_dependencies = project.get("github_workflow_job_dependencies", {})
     check_workflow_job_dependencies(workflow_job_dependencies, configured_workflow_jobs, jobs_by_workflow, errors)
     workflow_job_conditions = project.get("github_workflow_job_conditions", {})

--- a/scripts/product_contract/workflows.py
+++ b/scripts/product_contract/workflows.py
@@ -2382,9 +2382,10 @@ def check_esphome_version(product: dict, errors: list[str]) -> None:
         )
 
     docker_run_fragments = [
-        'local image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"',
+        'image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"',
+        'docker volume create "${workspace_volume}"',
         "container=$(docker create",
-        'docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"',
+        'docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"',
     ]
     if config_mount:
         require_contains(readme, f'-v "${{PWD}}:{config_mount}"', "README.md", errors)

--- a/scripts/product_contract/workflows.py
+++ b/scripts/product_contract/workflows.py
@@ -1208,16 +1208,22 @@ def check_workflow_job_runner_usage(
     expected_runner: str,
     workflow_texts: dict[str, tuple[str, str]],
     errors: list[str],
+    expected_job_runners: object = None,
 ) -> None:
     expected_runner = expected_runner.strip()
-    if not expected_runner:
+    job_runners = normalized_workflow_mapping(expected_job_runners) if isinstance(expected_job_runners, dict) else {}
+    if not expected_runner and not job_runners:
         return
 
-    for _, label, job_id, job_block in workflow_job_blocks(workflow_texts, errors):
+    for workflow_name, label, job_id, job_block in workflow_job_blocks(workflow_texts, errors):
+        target = f"{workflow_name}.{job_id}"
+        target_runner = job_runners.get(target, expected_runner)
+        if not target_runner:
+            continue
         actual_runner = workflow_job_runs_on(job_block)
         append_scalar_value_error(
             actual_runner,
-            expected_runner,
+            target_runner,
             f"{label} job {job_id} is missing runs-on",
             f"{label} job {job_id} runs-on",
             errors,
@@ -1713,8 +1719,8 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
             "release.build-firmware",
             "Compile firmware",
             [
-                f'"${{BUILD_DIR}}/{release_source_factory_binary}"',
-                "factory binary not found",
+                f'factory {release_source_factory_binary}',
+                f'"{release_build_output_dir}/${{{{ matrix.slug }}}}.factory.bin"',
             ],
             workflow_texts,
             errors,
@@ -1725,7 +1731,8 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
             "Compile firmware",
             [
                 '-s firmware_version "${VERSION}"',
-                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml"',
+                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}"',
+                '"${{ matrix.yaml }}.yaml" ota firmware.ota.bin',
             ],
             workflow_texts,
             errors,
@@ -1734,7 +1741,7 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
             "release.build-firmware",
             "Collect firmware files and generate manifest",
             [
-                f'"${{BUILD_DIR}}/{release_source_ota_binary}"',
+                f'"{release_build_output_dir}/${{{{ matrix.slug }}}}.ota.bin"',
                 "OTA binary not found",
             ],
             workflow_texts,
@@ -1767,26 +1774,24 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
             errors,
         )
     if release_esphome_cache_dir:
-        build_dir_fragment = 'BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"'
-        for target, step_names in (
-            ("compile.compile", ("Compile test firmware artifacts",)),
-            ("release.build-firmware", ("Compile firmware", "Collect firmware files and generate manifest")),
-        ):
-            for step_name in step_names:
-                check_workflow_named_step_run_contains(
-                    target,
-                    step_name,
-                    [build_dir_fragment],
-                    workflow_texts,
-                    errors,
-                )
+        build_dir_fragment = (
+            'local container_build_dir="${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}'
+            '/build/${{ matrix.build_name }}/build"'
+        )
+        for target in ("compile.compile", "release.build-firmware"):
+            check_workflow_named_step_run_contains(
+                target,
+                "Compile test firmware artifacts" if target == "compile.compile" else "Compile firmware",
+                [build_dir_fragment],
+                workflow_texts,
+                errors,
+            )
         for target in ("compile.compile", "release.build-firmware"):
             check_workflow_named_step_run_contains(
                 target,
                 "Fix ESPHome cache permissions",
                 [
                     'if [ -d "${RELEASE_ESPHOME_CACHE_DIR}" ]; then',
-                    'sudo chown -R "$USER:$USER" "${RELEASE_ESPHOME_CACHE_DIR}"',
                     'chmod -R u+rwX "${RELEASE_ESPHOME_CACHE_DIR}"',
                 ],
                 workflow_texts,
@@ -2245,7 +2250,10 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
         check_workflow_named_step_run_contains(
             "release.build-firmware",
             "Compile firmware",
-            ['compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml"'],
+            [
+                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}"',
+                '"${{ matrix.yaml }}.factory.yaml" factory firmware.factory.bin',
+            ],
             workflow_texts,
             errors,
         )
@@ -2253,8 +2261,9 @@ def check_device_workflow_contract(product: dict, errors: list[str]) -> None:
             "compile.compile",
             "Compile test firmware artifacts",
             [
-                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.factory.yaml"',
-                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${{ matrix.yaml }}.yaml"',
+                'compile "${ESPHOME_CONFIG_MOUNT}/builds/${config_file}"',
+                '"${{ matrix.yaml }}.factory.yaml" factory firmware.factory.bin',
+                '"${{ matrix.yaml }}.yaml" ota firmware.ota.bin',
             ],
             workflow_texts,
             errors,
@@ -2372,12 +2381,15 @@ def check_esphome_version(product: dict, errors: list[str]) -> None:
             errors,
         )
 
-    docker_run_fragments = ['"${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"']
+    docker_run_fragments = [
+        'local image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"',
+        "container=$(docker create",
+        'docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"',
+    ]
     if config_mount:
-        docker_run_fragments.append('-v "${PWD}:${ESPHOME_CONFIG_MOUNT}"')
         require_contains(readme, f'-v "${{PWD}}:{config_mount}"', "README.md", errors)
     if remove_container is True:
-        docker_run_fragments.append("docker run ${ESPHOME_DOCKER_REMOVE_FLAG}")
+        docker_run_fragments.append('docker rm -f "${container}"')
         require_contains(readme, "docker run --rm", "README.md", errors)
 
     for target, step_name in (
@@ -2425,7 +2437,12 @@ def check_workflows(product: dict, errors: list[str]) -> None:
     workflow_jobs = project.get("github_workflow_jobs", {})
     check_workflow_jobs(workflow_jobs, workflow_texts, errors)
     actions_runner = str(project.get("github_actions_runner", "")).strip()
-    check_workflow_job_runner_usage(actions_runner, workflow_texts, errors)
+    check_workflow_job_runner_usage(
+        actions_runner,
+        workflow_texts,
+        errors,
+        project.get("github_workflow_job_runners", {}),
+    )
     workflow_job_dependencies = project.get("github_workflow_job_dependencies", {})
     check_workflow_job_dependency_usage(workflow_job_dependencies, workflow_texts, errors)
     workflow_job_conditions = project.get("github_workflow_job_conditions", {})

--- a/scripts/product_contract/workflows.py
+++ b/scripts/product_contract/workflows.py
@@ -2385,7 +2385,7 @@ def check_esphome_version(product: dict, errors: list[str]) -> None:
         'image="${ESPHOME_DOCKER_IMAGE}:${ESPHOME_VERSION}"',
         'docker volume create "${workspace_volume}"',
         "container=$(docker create",
-        'docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"',
+        'docker cp --archive "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"',
     ]
     if config_mount:
         require_contains(readme, f'-v "${{PWD}}:{config_mount}"', "README.md", errors)

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -2715,6 +2715,7 @@ def test_trusted_workflows_target_the_dedicated_runner() -> None:
 
     assert "runs-on: ubuntu-latest" in compile_workflow
     assert compile_workflow.count("runs-on: espframe") == 2
+    assert "github.workflow }}-${{ github.event_name }}" in compile_workflow
     assert "runs-on: ubuntu-latest" not in docs_workflow
     assert "runs-on: ubuntu-latest" not in release_workflow
     assert docs_workflow.count("runs-on: espframe") == 3

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -2726,7 +2726,11 @@ def test_trusted_workflows_target_the_dedicated_runner() -> None:
 def test_firmware_workflows_copy_sources_into_isolated_docker() -> None:
     for workflow_name in ("compile.yml", "release.yml"):
         workflow_text = (ROOT / ".github" / "workflows" / workflow_name).read_text()
-        assert 'docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"' in workflow_text
+        assert 'docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"' in workflow_text
+        assert 'docker volume create "${workspace_volume}"' in workflow_text
+        assert 'docker volume rm -f "${workspace_volume}"' in workflow_text
+        assert "type=volume,source=${workspace_volume}" in workflow_text
+        assert 'rm -rf "${RELEASE_ESPHOME_CACHE_DIR}"' in workflow_text
         assert '-v "${PWD}:${ESPHOME_CONFIG_MOUNT}"' not in workflow_text
 
 

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -2720,6 +2720,7 @@ def test_trusted_workflows_target_the_dedicated_runner() -> None:
     assert docs_workflow.count("runs-on: espframe") == 3
     assert release_workflow.count("runs-on: espframe") == 4
     assert cleanup_workflow.count("runs-on: espframe") == 1
+    assert "docker volume prune --all --force" in cleanup_workflow
     assert '"tzdata==2026.3"' in compile_workflow
 
 
@@ -2728,8 +2729,8 @@ def test_firmware_workflows_copy_sources_into_isolated_docker() -> None:
         workflow_text = (ROOT / ".github" / "workflows" / workflow_name).read_text()
         assert "max-parallel: 1" in workflow_text
         assert "docker builder prune -af --keep-storage 2GB" in workflow_text
-        assert "docker volume prune -f" in workflow_text
-        assert 'docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"' in workflow_text
+        assert "docker volume prune --all --force" in workflow_text
+        assert 'docker cp --archive "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"' in workflow_text
         assert 'docker volume create "${workspace_volume}"' in workflow_text
         assert 'docker volume rm -f "${workspace_volume}"' in workflow_text
         assert "type=volume,source=${workspace_volume}" in workflow_text

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -2726,6 +2726,9 @@ def test_trusted_workflows_target_the_dedicated_runner() -> None:
 def test_firmware_workflows_copy_sources_into_isolated_docker() -> None:
     for workflow_name in ("compile.yml", "release.yml"):
         workflow_text = (ROOT / ".github" / "workflows" / workflow_name).read_text()
+        assert "max-parallel: 1" in workflow_text
+        assert "docker builder prune -af --keep-storage 2GB" in workflow_text
+        assert "docker volume prune -f" in workflow_text
         assert 'docker cp "${PWD}/." "${staging_container}:${ESPHOME_CONFIG_MOUNT}"' in workflow_text
         assert 'docker volume create "${workspace_volume}"' in workflow_text
         assert 'docker volume rm -f "${workspace_volume}"' in workflow_text

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -1062,6 +1062,18 @@ def test_workflow_job_runner_usage_rejects_drift_from_product_metadata() -> None
     ]
 
 
+def test_workflow_job_runner_usage_supports_per_job_runners() -> None:
+    errors: list[str] = []
+    check_workflow_job_runner_usage(
+        "ubuntu-latest",
+        {"compile": ("example.yml", RUNNER_WORKFLOW)},
+        errors,
+        {"compile.wrong": "macos-latest"},
+    )
+
+    assert errors == ["example.yml job missing is missing runs-on"]
+
+
 def test_workflow_job_timeout_minutes_reads_job_timeout() -> None:
     errors: list[str] = []
     assert workflow_job_timeout_minutes(
@@ -1702,12 +1714,15 @@ def test_workflow_named_step_run_contains_checks_compile_artifact_step() -> None
 
 
 def test_workflows_use_esphome_2026_build_artifact_directory() -> None:
-    artifact_dir = 'BUILD_DIR="${RELEASE_ESPHOME_CACHE_DIR}/build/${{ matrix.build_name }}/build"'
+    artifact_dir = (
+        'local container_build_dir="${ESPHOME_CONFIG_MOUNT}/${RELEASE_ESPHOME_CACHE_DIR}'
+        '/build/${{ matrix.build_name }}/build"'
+    )
     compile_workflow = (ROOT / ".github" / "workflows" / "compile.yml").read_text()
     release_workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
 
     assert artifact_dir in compile_workflow
-    assert release_workflow.count(artifact_dir) == 2
+    assert artifact_dir in release_workflow
 
 
 def test_workflow_named_step_run_contains_checks_compile_commands() -> None:
@@ -2690,6 +2705,29 @@ def test_docs_workflow_retains_only_five_complete_stable_releases() -> None:
     )
 
     assert errors == []
+
+
+def test_trusted_workflows_target_the_dedicated_runner() -> None:
+    compile_workflow = (ROOT / ".github" / "workflows" / "compile.yml").read_text()
+    docs_workflow = (ROOT / ".github" / "workflows" / "docs.yml").read_text()
+    release_workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
+    cleanup_workflow = (ROOT / ".github" / "workflows" / "runner-cleanup.yml").read_text()
+
+    assert "github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe'" in compile_workflow
+    assert compile_workflow.count("runs-on: espframe") == 2
+    assert "runs-on: ubuntu-latest" not in docs_workflow
+    assert "runs-on: ubuntu-latest" not in release_workflow
+    assert docs_workflow.count("runs-on: espframe") == 3
+    assert release_workflow.count("runs-on: espframe") == 4
+    assert cleanup_workflow.count("runs-on: espframe") == 1
+    assert '"tzdata==2026.3"' in compile_workflow
+
+
+def test_firmware_workflows_copy_sources_into_isolated_docker() -> None:
+    for workflow_name in ("compile.yml", "release.yml"):
+        workflow_text = (ROOT / ".github" / "workflows" / workflow_name).read_text()
+        assert 'docker cp "${PWD}/." "${container}:${ESPHOME_CONFIG_MOUNT}"' in workflow_text
+        assert '-v "${PWD}:${ESPHOME_CONFIG_MOUNT}"' not in workflow_text
 
 
 def main() -> int:

--- a/tests/workflow_contract_tests.py
+++ b/tests/workflow_contract_tests.py
@@ -2713,7 +2713,7 @@ def test_trusted_workflows_target_the_dedicated_runner() -> None:
     release_workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text()
     cleanup_workflow = (ROOT / ".github" / "workflows" / "runner-cleanup.yml").read_text()
 
-    assert "github.event_name == 'pull_request' && 'ubuntu-latest' || 'espframe'" in compile_workflow
+    assert "runs-on: ubuntu-latest" in compile_workflow
     assert compile_workflow.count("runs-on: espframe") == 2
     assert "runs-on: ubuntu-latest" not in docs_workflow
     assert "runs-on: ubuntu-latest" not in release_workflow


### PR DESCRIPTION
## What changes when merged

- Keep pull-request validation on GitHub-hosted runners while routing trusted firmware, docs, and release jobs to the dedicated `espframe` runner.
- Run a weekly full firmware compile and weekly bounded cleanup of the isolated Docker runtime.
- Serialize firmware matrix jobs, reclaim unused Docker storage before each build, and share sources/toolchains through a per-job Docker volume suited to the isolated DinD architecture.
- Pin timezone data for deterministic validation and extend the workflow product contract/tests for per-job runners.

## Automated checks

- [x] `npm run check:pr` passed locally
- [x] Pull-request `Validate PR Gate` passed
- [x] Manual end-to-end workflow passed on the dedicated runner

Additional validation:
- All workflow YAML parsed successfully.
- All embedded Bash run blocks passed `bash -n` syntax checks.
- Both display variants produced factory and OTA binaries, passed build-budget checks, and uploaded artifacts.

## Device testing

- [x] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [ ] Needs device testing before merge

PR Validation workflow run/artifact: https://github.com/jtenniswood/espframe/actions/runs/33321916699

Firmware artifacts: `firmware-test-immich-frame` and `firmware-test-immich-frame-v2`

Device tested: Not applicable

Result/notes: CI-only change; no firmware or device behavior changed.

## Notes for reviewers

- Pull-request code remains on `ubuntu-latest`; only trusted firmware, documentation, release, and cleanup work uses the self-hosted runner.
- The weekly compile is scheduled for Sunday 03:17 UTC, followed by runner cleanup at 04:47 UTC.
- Release and manual compile paths retain the existing ESPHome cache and artifact contracts.