### PR TITLE
Restore stable ESP32-P4 JPEG acceleration

### DIFF
--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -166,6 +166,10 @@ switch:
 # -----------------------------------------------------------------------------
 # 3-slot full-size ring buffer and portrait pair / preload remote_image components
 # -----------------------------------------------------------------------------
+# Immich's preview endpoint serves JPEG when explicitly requested. Pinning the
+# decoder avoids AUTO's format-selection race when several P4 slots finish near
+# each other, while `formats` keeps the software WebP decoder available to
+# configurations that opt back into AUTO.
 remote_image:
   - id: immich_img_0
     url: "${immich_image_initial_url}"
@@ -173,6 +177,7 @@ remote_image:
     type: RGB565
     byte_order: little_endian
     formats: [JPEG, WEBP]
+    format: JPEG
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -201,6 +206,7 @@ remote_image:
     type: RGB565
     byte_order: little_endian
     formats: [JPEG, WEBP]
+    format: JPEG
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -229,6 +235,7 @@ remote_image:
     type: RGB565
     byte_order: little_endian
     formats: [JPEG, WEBP]
+    format: JPEG
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -260,6 +267,7 @@ remote_image:
     type: RGB565
     byte_order: little_endian
     formats: [JPEG, WEBP]
+    format: JPEG
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -285,6 +293,7 @@ remote_image:
     type: RGB565
     byte_order: little_endian
     formats: [JPEG, WEBP]
+    format: JPEG
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -311,6 +320,7 @@ remote_image:
     type: RGB565
     byte_order: little_endian
     formats: [JPEG, WEBP]
+    format: JPEG
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -343,6 +353,7 @@ remote_image:
     type: RGB565
     byte_order: little_endian
     formats: [JPEG, WEBP]
+    format: JPEG
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -166,18 +166,17 @@ switch:
 # -----------------------------------------------------------------------------
 # 3-slot full-size ring buffer and portrait pair / preload remote_image components
 # -----------------------------------------------------------------------------
-# Immich's preview endpoint serves JPEG when explicitly requested. Pinning the
-# decoder avoids AUTO's format-selection race when several P4 slots finish near
-# each other, while `formats` keeps the software WebP decoder available to
-# configurations that opt back into AUTO.
+# Immich can serve previews in a server-configured format. Keep automatic
+# response detection enabled so non-JPEG data is rejected safely instead of
+# being passed to the JPEG decoder. WebP remains disabled on P4 because its
+# software decoder is not stable alongside this display workload.
 remote_image:
   - id: immich_img_0
     url: "${immich_image_initial_url}"
     resize: ${display_width}x${display_height}
     type: RGB565
     byte_order: little_endian
-    formats: [JPEG, WEBP]
-    format: JPEG
+    formats: [JPEG]
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -205,8 +204,7 @@ remote_image:
     resize: ${display_width}x${display_height}
     type: RGB565
     byte_order: little_endian
-    formats: [JPEG, WEBP]
-    format: JPEG
+    formats: [JPEG]
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -234,8 +232,7 @@ remote_image:
     resize: ${display_width}x${display_height}
     type: RGB565
     byte_order: little_endian
-    formats: [JPEG, WEBP]
-    format: JPEG
+    formats: [JPEG]
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -266,8 +263,7 @@ remote_image:
     horizontal_align: END
     type: RGB565
     byte_order: little_endian
-    formats: [JPEG, WEBP]
-    format: JPEG
+    formats: [JPEG]
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -292,8 +288,7 @@ remote_image:
     horizontal_align: START
     type: RGB565
     byte_order: little_endian
-    formats: [JPEG, WEBP]
-    format: JPEG
+    formats: [JPEG]
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -319,8 +314,7 @@ remote_image:
     horizontal_align: END
     type: RGB565
     byte_order: little_endian
-    formats: [JPEG, WEBP]
-    format: JPEG
+    formats: [JPEG]
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:
@@ -352,8 +346,7 @@ remote_image:
     horizontal_align: START
     type: RGB565
     byte_order: little_endian
-    formats: [JPEG, WEBP]
-    format: JPEG
+    formats: [JPEG]
     request_headers:
       x-api-key: !lambda 'return id(immich_api_key_text).state;'
     on_download_finished:

--- a/components/remote_image/image_decoder.cpp
+++ b/components/remote_image/image_decoder.cpp
@@ -154,6 +154,38 @@ void ImageDecoder::draw_rgb565_block(int x, int y, int w, int h, const uint8_t *
   }
 }
 
+bool ImageDecoder::draw_rgb565_scaled_chunk(const uint8_t *data, int src_stride, int src_height,
+                                            int &next_dst_y, int max_rows) {
+  if (data == nullptr || src_stride <= 0 || src_height <= 0 || max_rows <= 0 || this->y_scale_ <= 0) {
+    return true;
+  }
+
+  const int dst_y_start = std::max(0, this->y_offset_);
+  const int dst_y_end = std::min(this->image_->buffer_height_, this->y_offset_ + this->scaled_height_);
+  if (next_dst_y < dst_y_start) next_dst_y = dst_y_start;
+  if (next_dst_y >= dst_y_end) return true;
+
+  const int dst_x_start = std::max(0, this->x_offset_);
+  const int dst_x_end = std::min(this->image_->buffer_width_, this->x_offset_ + this->scaled_width_);
+  const int chunk_end = std::min(dst_y_end, next_dst_y + max_rows);
+  auto *dst_pixels = reinterpret_cast<uint16_t *>(this->image_->buffer_);
+  const auto *src_pixels = reinterpret_cast<const uint16_t *>(data);
+
+  for (; next_dst_y < chunk_end; next_dst_y++) {
+    const int relative_y = next_dst_y - this->y_offset_;
+    // Match the existing source-row renderer: when multiple source rows map to
+    // one destination row, the last source row wins.
+    int src_y = static_cast<int>(std::ceil((relative_y + 1) / this->y_scale_)) - 1;
+    src_y = std::max(0, std::min(src_y, src_height - 1));
+    const uint16_t *src_row = src_pixels + static_cast<size_t>(src_y) * src_stride;
+    uint16_t *dst_row = dst_pixels + static_cast<size_t>(next_dst_y) * this->image_->buffer_width_;
+    for (int dst_x = dst_x_start; dst_x < dst_x_end; dst_x++) {
+      dst_row[dst_x] = src_row[this->src_x_lut_[dst_x - this->x_offset_]];
+    }
+  }
+  return next_dst_y >= dst_y_end;
+}
+
 void ImageDecoder::draw_rgb888_scaled(int src_y, int src_w, const uint8_t *rgb888, bool big_endian) {
   int dst_y = static_cast<int>(src_y * this->y_scale_) + this->y_offset_;
   if (dst_y < 0 || dst_y >= this->image_->buffer_height_)

--- a/components/remote_image/image_decoder.h
+++ b/components/remote_image/image_decoder.h
@@ -88,6 +88,22 @@ class ImageDecoder {
   void draw_rgb565_block(int x, int y, int w, int h, const uint8_t *data);
 
   /**
+   * @brief Copy a bounded number of destination rows from a complete RGB565
+   * source image. Unlike draw_rgb565_block(), this walks destination rows, so
+   * downscaling touches each displayed pixel once instead of revisiting rows
+   * that will be discarded.
+   *
+   * @param data Complete source image buffer.
+   * @param src_stride Source row stride in pixels.
+   * @param src_height Source image height in pixels.
+   * @param next_dst_y In/out destination row cursor; initialize to -1.
+   * @param max_rows Maximum destination rows to copy in this call.
+   * @return true when every visible destination row has been copied.
+   */
+  bool draw_rgb565_scaled_chunk(const uint8_t *data, int src_stride, int src_height,
+                                int &next_dst_y, int max_rows);
+
+  /**
    * @brief Convert RGB888 source pixels to RGB565 and write only the sampled
    * destination pixels. Combines color conversion with nearest-neighbor
    * downscaling in a single pass, avoiding work on source pixels that would

--- a/components/remote_image/jpeg_accelerator_helpers.h
+++ b/components/remote_image/jpeg_accelerator_helpers.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace esphome {
+namespace remote_image {
+
+// Keep the P4 accelerator's PSRAM footprint fixed after its first use. Immich's
+// normal preview is comfortably below both limits; unusual or user-tuned large
+// previews retain the software decoder fallback instead of growing and
+// repeatedly replacing multi-megabyte DMA buffers.
+static constexpr size_t P4_JPEG_MAX_INPUT_BYTES = 1 * 1024 * 1024;
+static constexpr size_t P4_JPEG_MAX_DECODED_BYTES = 6 * 1024 * 1024;
+
+struct P4JpegInfo {
+  uint32_t width{0};
+  uint32_t height{0};
+  uint32_t padded_width{0};
+  uint32_t padded_height{0};
+  size_t decoded_bytes{0};
+};
+
+inline bool parse_p4_baseline_jpeg(const uint8_t *buffer, size_t size, P4JpegInfo *info) {
+  if (buffer == nullptr || info == nullptr || size < 4 || buffer[0] != 0xFF || buffer[1] != 0xD8) {
+    return false;
+  }
+
+  size_t offset = 2;
+  while (offset + 1 < size) {
+    while (offset < size && buffer[offset] != 0xFF) offset++;
+    while (offset < size && buffer[offset] == 0xFF) offset++;
+    if (offset >= size) return false;
+
+    const uint8_t marker = buffer[offset++];
+    if (marker == 0x00 || marker == 0xD8 || (marker >= 0xD0 && marker <= 0xD7)) continue;
+    if (marker == 0xD9 || marker == 0xDA) return false;
+    if (offset + 2 > size) return false;
+
+    const size_t segment_size = (static_cast<size_t>(buffer[offset]) << 8) | buffer[offset + 1];
+    if (segment_size < 2 || segment_size > size - offset) return false;
+
+    if (marker == 0xC0) {
+      // SOF0: length, precision, height, width, component count, then three
+      // bytes per component. P4 supports 8-bit, three-component baseline JPEG
+      // with 4:4:4, 4:2:2, or 4:2:0 luma sampling.
+      if (segment_size < 17 || buffer[offset + 2] != 8 || buffer[offset + 7] != 3) return false;
+      const uint32_t height = (static_cast<uint32_t>(buffer[offset + 3]) << 8) | buffer[offset + 4];
+      const uint32_t width = (static_cast<uint32_t>(buffer[offset + 5]) << 8) | buffer[offset + 6];
+      if (width == 0 || height == 0) return false;
+
+      uint32_t mcu_width = 0;
+      uint32_t mcu_height = 0;
+      switch (buffer[offset + 9]) {
+        case 0x11:
+          mcu_width = 8;
+          mcu_height = 8;
+          break;
+        case 0x21:
+          mcu_width = 16;
+          mcu_height = 8;
+          break;
+        case 0x22:
+          mcu_width = 16;
+          mcu_height = 16;
+          break;
+        default:
+          return false;
+      }
+      if (buffer[offset + 12] != 0x11 || buffer[offset + 15] != 0x11) return false;
+
+      const uint64_t padded_width = (static_cast<uint64_t>(width) + mcu_width - 1) / mcu_width * mcu_width;
+      const uint64_t padded_height = (static_cast<uint64_t>(height) + mcu_height - 1) / mcu_height * mcu_height;
+      const uint64_t decoded_bytes = padded_width * padded_height * 2;
+      if (padded_width > std::numeric_limits<uint32_t>::max() ||
+          padded_height > std::numeric_limits<uint32_t>::max() ||
+          decoded_bytes > std::numeric_limits<size_t>::max()) {
+        return false;
+      }
+
+      info->width = width;
+      info->height = height;
+      info->padded_width = static_cast<uint32_t>(padded_width);
+      info->padded_height = static_cast<uint32_t>(padded_height);
+      info->decoded_bytes = static_cast<size_t>(decoded_bytes);
+      return true;
+    }
+
+    // Any other start-of-frame marker describes a progressive, lossless, or
+    // extended JPEG mode unsupported by the ESP32-P4 hardware block.
+    if (marker >= 0xC1 && marker <= 0xCF && marker != 0xC4 && marker != 0xC8 && marker != 0xCC) {
+      return false;
+    }
+    offset += segment_size;
+  }
+  return false;
+}
+
+inline bool p4_jpeg_fits_workspace(const P4JpegInfo &info, size_t input_bytes) {
+  return input_bytes > 0 && input_bytes <= P4_JPEG_MAX_INPUT_BYTES &&
+         info.decoded_bytes > 0 && info.decoded_bytes <= P4_JPEG_MAX_DECODED_BYTES;
+}
+
+}  // namespace remote_image
+}  // namespace esphome

--- a/components/remote_image/jpeg_image.cpp
+++ b/components/remote_image/jpeg_image.cpp
@@ -1,20 +1,124 @@
 #include "jpeg_image.h"
 #ifdef USE_REMOTE_IMAGE_JPEG_SUPPORT
 
+#include <cinttypes>
+#include <cstring>
+
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include "jpeg_accelerator_helpers.h"
 #include "remote_image.h"
 
-// JPEG decoding is handled as a two-stage process: first collect the full file
-// into the download buffer because libjpeg-turbo expects seekable memory, then
-// decompress scanlines in small chunks so ESPHome's main loop can keep running.
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+#include "driver/jpeg_decode.h"
+#include "esp_heap_caps.h"
+#endif
+
+// JPEG decoding first collects the full file into the download buffer. P4 can
+// then decode eligible previews into a reusable DMA workspace; every other
+// target and JPEG mode uses libjpeg-turbo scanlines in bounded loop chunks.
 static const char *const TAG = "remote_image.jpeg";
 
 namespace esphome {
 namespace remote_image {
+
+// Multiple slideshow slots can finish downloading close together. Decode one
+// complete JPEG at a time so the software fallback and the shared P4 hardware
+// workspace never overlap their peak memory use.
+static JpegDecoder *active_decoder_owner = nullptr;
+
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+struct P4JpegWorkspace {
+  jpeg_decoder_handle_t decoder{nullptr};
+  uint8_t *input{nullptr};
+  size_t input_capacity{0};
+  uint8_t *decoded{nullptr};
+  size_t decoded_capacity{0};
+  bool disabled{false};
+  uint32_t attempts{0};
+  uint32_t successes{0};
+  uint32_t fallbacks{0};
+  uint32_t consecutive_failures{0};
+  size_t min_internal_largest{SIZE_MAX};
+  size_t min_psram_largest{SIZE_MAX};
+
+  void release() {
+    if (this->decoder != nullptr) {
+      jpeg_del_decoder_engine(this->decoder);
+      this->decoder = nullptr;
+    }
+    free(this->input);
+    this->input = nullptr;
+    this->input_capacity = 0;
+    free(this->decoded);
+    this->decoded = nullptr;
+    this->decoded_capacity = 0;
+  }
+
+  void disable(const char *reason) {
+    if (!this->disabled) ESP_LOGW(TAG, "Disabling P4 JPEG acceleration for this boot: %s", reason);
+    this->disabled = true;
+    this->release();
+  }
+
+  bool ensure_ready() {
+    if (this->disabled) return false;
+    if (this->decoder != nullptr && this->input != nullptr && this->decoded != nullptr) return true;
+
+    jpeg_decode_memory_alloc_cfg_t output_cfg{};
+    output_cfg.buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER;
+    this->decoded = static_cast<uint8_t *>(
+        jpeg_alloc_decoder_mem(P4_JPEG_MAX_DECODED_BYTES, &output_cfg, &this->decoded_capacity));
+
+    jpeg_decode_memory_alloc_cfg_t input_cfg{};
+    input_cfg.buffer_direction = JPEG_DEC_ALLOC_INPUT_BUFFER;
+    this->input = static_cast<uint8_t *>(
+        jpeg_alloc_decoder_mem(P4_JPEG_MAX_INPUT_BYTES, &input_cfg, &this->input_capacity));
+
+    if (this->decoded == nullptr || this->decoded_capacity < P4_JPEG_MAX_DECODED_BYTES ||
+        this->input == nullptr || this->input_capacity < P4_JPEG_MAX_INPUT_BYTES) {
+      this->disable("fixed DMA workspace allocation failed");
+      return false;
+    }
+
+    jpeg_decode_engine_cfg_t engine_cfg{};
+    engine_cfg.timeout_ms = 1000;
+    const esp_err_t err = jpeg_new_decoder_engine(&engine_cfg, &this->decoder);
+    if (err != ESP_OK) {
+      this->decoder = nullptr;
+      this->disable("JPEG decoder engine initialization failed");
+      return false;
+    }
+
+    ESP_LOGI(TAG, "Initialized fixed P4 JPEG workspace: input=%zu decoded=%zu",
+             this->input_capacity, this->decoded_capacity);
+    return true;
+  }
+
+  void record_memory() {
+    const size_t internal_largest =
+        heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    const size_t psram_largest = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    this->min_internal_largest = std::min(this->min_internal_largest, internal_largest);
+    this->min_psram_largest = std::min(this->min_psram_largest, psram_largest);
+    if ((this->successes % 25) == 0) {
+      ESP_LOGI(TAG,
+               "P4 JPEG stability: attempts=%" PRIu32 " hardware=%" PRIu32 " fallback=%" PRIu32
+               " internal_free=%zu internal_largest=%zu internal_largest_min=%zu"
+               " psram_free=%zu psram_largest=%zu psram_largest_min=%zu",
+               this->attempts, this->successes, this->fallbacks,
+               heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT), internal_largest,
+               this->min_internal_largest, heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT), psram_largest,
+               this->min_psram_largest);
+    }
+  }
+};
+
+static P4JpegWorkspace p4_jpeg_workspace;
+#endif
 
 static void jpeg_error_exit(j_common_ptr cinfo) {
   auto *err = reinterpret_cast<JpegErrorMgr *>(cinfo->err);
@@ -36,11 +140,15 @@ void JpegDecoder::cleanup_() {
     free(this->row_buffer_);
     this->row_buffer_ = nullptr;
   }
+  if (active_decoder_owner == this) active_decoder_owner = nullptr;
   this->phase_ = WAITING;
 }
 
 int JpegDecoder::prepare(size_t download_size) {
   ImageDecoder::prepare(download_size);
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+  this->hardware_attempted_ = false;
+#endif
   auto size = this->image_->resize_download_buffer(download_size);
   if (size < download_size) {
     ESP_LOGE(TAG, "Download buffer resize failed!");
@@ -49,16 +157,141 @@ int JpegDecoder::prepare(size_t download_size) {
   return 0;
 }
 
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+bool JpegDecoder::try_start_hardware_decode_(uint8_t *buffer, size_t size) {
+  this->hardware_attempted_ = true;
+  if (p4_jpeg_workspace.disabled || this->image_->image_type() != image::ImageType::IMAGE_TYPE_RGB565 ||
+      size > UINT32_MAX) {
+    return false;
+  }
+
+  p4_jpeg_workspace.attempts++;
+  P4JpegInfo info;
+  if (!parse_p4_baseline_jpeg(buffer, size, &info)) {
+    p4_jpeg_workspace.fallbacks++;
+    ESP_LOGD(TAG, "JPEG is not an eligible three-component baseline stream; using software");
+    return false;
+  }
+  if (!p4_jpeg_fits_workspace(info, size)) {
+    p4_jpeg_workspace.fallbacks++;
+    ESP_LOGD(TAG, "JPEG exceeds fixed P4 workspace: input=%zu decoded=%zu", size, info.decoded_bytes);
+    return false;
+  }
+
+  const int target_w = this->image_->get_fixed_width();
+  const int target_h = this->image_->get_fixed_height();
+  if (target_w <= 0 || target_h <= 0) {
+    p4_jpeg_workspace.fallbacks++;
+    ESP_LOGD(TAG, "JPEG target is auto-sized; using software decoder");
+    return false;
+  }
+  const double scale_x = static_cast<double>(target_w) / info.width;
+  const double scale_y = static_cast<double>(target_h) / info.height;
+  const double desired_scale = this->image_->is_fill_mode() ? std::max(scale_x, scale_y)
+                                                            : std::min(scale_x, scale_y);
+  // Libjpeg's native IDCT scaling is already efficient for small images. Keep
+  // the large fixed DMA workspace for previews that actually need downscaling.
+  if (desired_scale >= 1.0) {
+    p4_jpeg_workspace.fallbacks++;
+    ESP_LOGD(TAG, "JPEG would be upscaled (%.3f); using software decoder", desired_scale);
+    return false;
+  }
+
+  if (!p4_jpeg_workspace.ensure_ready()) {
+    p4_jpeg_workspace.fallbacks++;
+    return false;
+  }
+
+  this->hardware_started_us_ = micros();
+  memcpy(p4_jpeg_workspace.input, buffer, size);
+
+  jpeg_decode_cfg_t decode_cfg{};
+  decode_cfg.output_format = JPEG_DECODE_OUT_FORMAT_RGB565;
+  decode_cfg.rgb_order = this->image_->is_big_endian() ? JPEG_DEC_RGB_ELEMENT_ORDER_RGB
+                                                        : JPEG_DEC_RGB_ELEMENT_ORDER_BGR;
+  decode_cfg.conv_std = JPEG_YUV_RGB_CONV_STD_BT601;
+  uint32_t decoded_size = 0;
+  const esp_err_t err = jpeg_decoder_process(
+      p4_jpeg_workspace.decoder, &decode_cfg, p4_jpeg_workspace.input, static_cast<uint32_t>(size),
+      p4_jpeg_workspace.decoded, static_cast<uint32_t>(p4_jpeg_workspace.decoded_capacity), &decoded_size);
+  this->hardware_decode_us_ = micros() - this->hardware_started_us_;
+  if (err != ESP_OK || decoded_size < info.decoded_bytes) {
+    p4_jpeg_workspace.fallbacks++;
+    p4_jpeg_workspace.consecutive_failures++;
+    ESP_LOGW(TAG, "P4 JPEG decode failed (%s, output=%" PRIu32 "/%zu); using software",
+             esp_err_to_name(err), decoded_size, info.decoded_bytes);
+    if (err == ESP_ERR_TIMEOUT || p4_jpeg_workspace.consecutive_failures >= 3) {
+      p4_jpeg_workspace.disable(err == ESP_ERR_TIMEOUT ? "hardware decode timed out"
+                                                       : "three consecutive hardware decode failures");
+    }
+    return false;
+  }
+
+  p4_jpeg_workspace.consecutive_failures = 0;
+  if (!this->set_size(static_cast<int>(info.width), static_cast<int>(info.height))) {
+    p4_jpeg_workspace.fallbacks++;
+    return false;
+  }
+
+  this->hardware_src_width_ = info.width;
+  this->hardware_src_height_ = info.height;
+  this->hardware_stride_ = info.padded_width;
+  this->hardware_draw_y_ = -1;
+  this->hardware_draw_us_ = 0;
+  this->phase_ = HARDWARE_DRAWING;
+  return true;
+}
+
+void JpegDecoder::continue_hardware_draw_() {
+  const uint32_t started_us = micros();
+  const bool finished = this->draw_rgb565_scaled_chunk(
+      p4_jpeg_workspace.decoded, static_cast<int>(this->hardware_stride_),
+      static_cast<int>(this->hardware_src_height_), this->hardware_draw_y_,
+      HARDWARE_DRAW_ROWS_PER_CHUNK);
+  this->hardware_draw_us_ += micros() - started_us;
+  App.feed_wdt();
+  if (!finished) return;
+
+  p4_jpeg_workspace.successes++;
+  p4_jpeg_workspace.record_memory();
+  ESP_LOGD(TAG,
+           "P4 JPEG src=%" PRIu32 "x%" PRIu32 " decode=%" PRIu32 "us draw=%" PRIu32
+           "us total=%" PRIu32 "us",
+           this->hardware_src_width_, this->hardware_src_height_, this->hardware_decode_us_,
+           this->hardware_draw_us_, micros() - this->hardware_started_us_);
+  if (active_decoder_owner == this) active_decoder_owner = nullptr;
+  this->phase_ = FINISHED;
+}
+#endif
+
 int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
   if (this->phase_ == FINISHED) {
     return size;
   }
+
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+  if (this->phase_ == HARDWARE_DRAWING) {
+    this->continue_hardware_draw_();
+    if (this->phase_ == FINISHED) {
+      this->decoded_bytes_ = size;
+      return size;
+    }
+    return 0;
+  }
+#endif
 
   if (this->phase_ == WAITING) {
     if (size < this->download_size_) {
       ESP_LOGV(TAG, "Download not complete. Size: %zu/%zu", size, this->download_size_);
       return 0;
     }
+
+    if (active_decoder_owner != nullptr && active_decoder_owner != this) return 0;
+    active_decoder_owner = this;
+
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+    if (!this->hardware_attempted_ && this->try_start_hardware_decode_(buffer, size)) return 0;
+#endif
 
     this->cinfo_ = new jpeg_decompress_struct();
     this->jerr_ = new JpegErrorMgr();

--- a/components/remote_image/jpeg_image.h
+++ b/components/remote_image/jpeg_image.h
@@ -24,9 +24,13 @@ class JpegDecoder : public ImageDecoder {
   int HOT decode(uint8_t *buffer, size_t size) override;
 
  private:
-  enum Phase { WAITING, DECOMPRESSING, FINISHED };
+  enum Phase { WAITING, HARDWARE_DRAWING, DECOMPRESSING, FINISHED };
 
   void cleanup_();
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+  bool try_start_hardware_decode_(uint8_t *buffer, size_t size);
+  void continue_hardware_draw_();
+#endif
 
   Phase phase_ = WAITING;
   jpeg_decompress_struct *cinfo_ = nullptr;
@@ -39,8 +43,19 @@ class JpegDecoder : public ImageDecoder {
   bool use_rgb565_ = false;
   bool big_endian_ = false;
   bool scaling_ = false;
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+  bool hardware_attempted_ = false;
+  uint32_t hardware_src_width_ = 0;
+  uint32_t hardware_src_height_ = 0;
+  uint32_t hardware_stride_ = 0;
+  int hardware_draw_y_ = -1;
+  uint32_t hardware_started_us_ = 0;
+  uint32_t hardware_decode_us_ = 0;
+  uint32_t hardware_draw_us_ = 0;
+#endif
 
   static constexpr int SCANLINES_PER_CHUNK = 100;
+  static constexpr int HARDWARE_DRAW_ROWS_PER_CHUNK = 32;
 };
 
 }  // namespace remote_image

--- a/components/remote_image/remote_image.h
+++ b/components/remote_image/remote_image.h
@@ -247,6 +247,8 @@ class OnlineImage : public PollingComponent,
   friend bool ImageDecoder::set_size(int width, int height);
   friend void ImageDecoder::draw(int x, int y, int w, int h, const Color &color);
   friend void ImageDecoder::draw_rgb565_block(int x, int y, int w, int h, const uint8_t *data);
+  friend bool ImageDecoder::draw_rgb565_scaled_chunk(const uint8_t *data, int src_stride, int src_height,
+                                                      int &next_dst_y, int max_rows);
   friend void ImageDecoder::draw_rgb888_scaled(int src_y, int src_w, const uint8_t *rgb888, bool big_endian);
   friend void ImageDecoder::fill_row_gap(int gap_start, int gap_end, int src_row_y);
   friend void ImageDecoder::fill_trailing_row_gap(int gap_start);

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -28,7 +28,7 @@ esp32:
       # Keep large HTTP/JSON/C++ allocations out of scarce internal RAM. TLS,
       # Wi-Fi, and DMA still retain a dedicated internal-memory reserve.
       CONFIG_SPIRAM_USE_MALLOC: "y"
-      CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL: "12288"
+      CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL: "4096"
       CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL: "32768"
       CONFIG_MBEDTLS_DEFAULT_MEM_ALLOC: "y"
       # Some modern reverse proxies offer TLS 1.3 only. Enable it alongside

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -28,7 +28,7 @@ esp32:
       # Keep large HTTP/JSON/C++ allocations out of scarce internal RAM. TLS,
       # Wi-Fi, and DMA still retain a dedicated internal-memory reserve.
       CONFIG_SPIRAM_USE_MALLOC: "y"
-      CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL: "12288"
+      CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL: "4096"
       CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL: "32768"
       CONFIG_MBEDTLS_DEFAULT_MEM_ALLOC: "y"
       # Some modern reverse proxies offer TLS 1.3 only. Enable it alongside

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -2,11 +2,13 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "components/espframe/date_utils.h"
 #include "components/espframe/configuration_contract_generated.h"
 #include "components/espframe/duration_helpers.h"
 #include "components/espframe/immich_helpers.h"
+#include "components/remote_image/jpeg_accelerator_helpers.h"
 
 struct PhotoMeta {
   std::string asset_id, image_url, date, location, person;
@@ -162,6 +164,49 @@ static void test_duration_helpers() {
   assert(parse_duration_option_seconds("5 seconds", 15, 10, 86400) == 10);
   assert(parse_duration_option_seconds("48 hours", 15, 10, 86400) == 86400);
   assert(parse_duration_option_seconds("", 15, 10, 86400) == 15);
+}
+
+static void test_p4_jpeg_accelerator_helpers() {
+  const std::vector<uint8_t> baseline{
+      0xFF, 0xD8,
+      0xFF, 0xE0, 0x00, 0x04, 0x00, 0x00,
+      0xFF, 0xC0, 0x00, 0x11, 0x08, 0x05, 0xA0, 0x07, 0x7E, 0x03,
+      0x01, 0x22, 0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01,
+      0xFF, 0xDA,
+  };
+  esphome::remote_image::P4JpegInfo info;
+  assert(esphome::remote_image::parse_p4_baseline_jpeg(baseline.data(), baseline.size(), &info));
+  assert(info.width == 1918);
+  assert(info.height == 1440);
+  assert(info.padded_width == 1920);
+  assert(info.padded_height == 1440);
+  assert(info.decoded_bytes == 1920u * 1440u * 2u);
+  assert(esphome::remote_image::p4_jpeg_fits_workspace(info, baseline.size()));
+  const auto baseline_info = info;
+
+  esphome::remote_image::P4JpegInfo largest_live_preview{
+      2160, 1440, 2160, 1440, 2160u * 1440u * 2u};
+  assert(esphome::remote_image::p4_jpeg_fits_workspace(largest_live_preview, baseline.size()));
+
+  auto progressive = baseline;
+  progressive[9] = 0xC2;
+  assert(!esphome::remote_image::parse_p4_baseline_jpeg(
+      progressive.data(), progressive.size(), &info));
+
+  auto grayscale = baseline;
+  grayscale[17] = 0x01;
+  assert(!esphome::remote_image::parse_p4_baseline_jpeg(grayscale.data(), grayscale.size(), &info));
+
+  auto invalid_segment = baseline;
+  invalid_segment[10] = 0x00;
+  invalid_segment[11] = 0x01;
+  assert(!esphome::remote_image::parse_p4_baseline_jpeg(
+      invalid_segment.data(), invalid_segment.size(), &info));
+
+  esphome::remote_image::P4JpegInfo oversized{4096, 4096, 4096, 4096, 4096u * 4096u * 2u};
+  assert(!esphome::remote_image::p4_jpeg_fits_workspace(oversized, baseline.size()));
+  assert(!esphome::remote_image::p4_jpeg_fits_workspace(
+      baseline_info, esphome::remote_image::P4_JPEG_MAX_INPUT_BYTES + 1));
 }
 
 static void test_immich_body_helpers() {
@@ -1606,6 +1651,7 @@ static void test_configuration_contract_capabilities() {
 int main() {
   test_date_and_url_helpers();
   test_duration_helpers();
+  test_p4_jpeg_accelerator_helpers();
   test_immich_body_helpers();
   test_smart_filter_helpers();
   test_immich_request_state();


### PR DESCRIPTION
## What changes when merged

- Restores ESP32-P4 hardware JPEG decoding for eligible baseline, three-component Immich previews.
- Uses one persistent 1 MiB input / 6 MiB RGB565 DMA workspace and one reusable decoder engine, avoiding the repeated multi-megabyte allocation/free cycle behind the fragmentation and reset behavior from #176.
- Scales the completed hardware output into the existing image buffer in bounded 32-row loop chunks; no PPA staging buffer is needed.
- Serializes JPEG decoders and falls back to the existing software decoder for progressive, grayscale, oversized, auto-sized, upscaled, unsupported, or failed hardware inputs.
- Disables acceleration for the remainder of the boot after a timeout or three consecutive driver failures.
- Keeps automatic content detection enabled for Immich preview slots while accepting JPEG only. Non-JPEG responses, including WebP, are rejected safely instead of being sent to the JPEG decoder.
- Reduces `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL` from 12 KiB to 4 KiB on both P4 variants, improving the usable internal heap while preserving the existing 32 KiB internal reserve.
- Adds host-side coverage for JPEG eligibility parsing, MCU padding, and fixed-workspace limits.

## Automated checks

- [ ] `npm run check:pr` passed
- [ ] CI checks are expected to pass

Local `npm run check:pr` completed all repository, typecheck, compatibility, smoke CLI, contract, budget, helper, and documentation checks. Its Chromium browser step was blocked by the local environment because `xdg-settings` is unavailable; the required GitHub PR gate covers that step.

Additional compile checks:

- Exact final commit `2f26a54`, original Guition P4 panel — passed with ESPHome 2026.7.4 / ESP-IDF 5.5.5 (DIRAM 137,610 bytes / 23.87%, firmware 2,606,358 bytes)
- `builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml` — passed with ESPHome 2026.7.4 / ESP-IDF 5.5.5 (DIRAM 137,610 bytes / 23.87%, firmware 2,606,282 bytes)

## Device testing

- [ ] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [ ] Needs device testing before merge
- [x] Exact branch commit flashed locally and tested

Device tested: Guition ESP32-P4 JC8012P4A1 (original panel), OTA at `192.168.6.106`

Result/notes:

- The hardware-accelerated JPEG implementation completed a 9h31m device soak without a reset. A focused 38m20s run recorded 442 decode attempts, 125 hardware successes, and 317 clean software fallbacks, with no reset or hardware fault.
- At the focused-run checkpoint, internal largest-block low-water was 20,480 B under monitor load and recovered to 31,744 B; PSRAM remained stable.
- Exact final commit `2f26a54` compiled and OTA-uploaded in 20.41s. It booted with reset reason `Reboot request from esphome.ota`, passed the rollback window, and remained continuously up during the post-flash soak.
- During that exact-build soak, internal largest block was 31,744 B under SSE monitoring; free internal heap recovered from 12.5% to 14.7%. PSRAM was about 39% free with an 11,272,192 B largest block.
- Full AUTO JPEG+WebP builds could OTA successfully but repeatedly panicked during startup and triggered OTA rollback. No serial console was available to capture the precise panic. The stable boundary therefore retains AUTO content sniffing but accepts JPEG only; WebP is an explicit documented limitation on this P4 configuration.
- Progressive and otherwise ineligible JPEGs fall back cleanly to the software JPEG decoder.

## Notes for reviewers

- Hardware acceleration remains P4-only and deliberately bounded. Unsupported JPEG inputs retain the established libjpeg-turbo path.
- The workspace is allocated once on first eligible use and retained for the boot, trading a fixed 7 MiB PSRAM reservation for stable allocation behavior.
- WebP is intentionally not enabled on these Immich slots because it was not stable on the test device. AUTO sniffing prevents mislabeled content from reaching the JPEG decoder.
- Stability counters and minimum-largest-block telemetry are logged every 25 hardware successes to make longer device soaks auditable.
