### PR TITLE
Use icon-only slideshow navigation feedback

### DIFF
--- a/devices/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
@@ -2,8 +2,8 @@
 # ICONS - Material Design Icons for setup and UI
 # =============================================================================
 # Single icon font (MaterialDesign-Webfont) with glyphs used by the device
-# screens. Substitutions expose Unicode codepoints for WiFi and cog (settings)
-# so other YAML can reference icon_wifi / icon_cog without hardcoding.
+# screens. Substitutions expose Unicode codepoints so other YAML can reference
+# the icons without hardcoding them.
 # =============================================================================
 
 font:
@@ -15,11 +15,15 @@ font:
       - "\U000F05A9"  # mdi-wifi
       - "\U000F0493"  # mdi-cog
       - "\U000F0164"  # mdi-cloud-off-outline
+      - "\U000F0141"  # mdi-chevron-left
+      - "\U000F0142"  # mdi-chevron-right
 
 # -----------------------------------------------------------------------------
-# Substitutions for use in labels/buttons (mdi-wifi, mdi-cog, mdi-cloud-off-outline)
+# Substitutions for use in labels/buttons
 # -----------------------------------------------------------------------------
 substitutions:
   icon_wifi: "\U000F05A9"
   icon_cog: "\U000F0493"
   icon_cloud_off: "\U000F0164"
+  icon_chevron_left: "\U000F0141"
+  icon_chevron_right: "\U000F0142"

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_loading.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_loading.yaml
@@ -46,7 +46,7 @@ script:
             - script.execute: setup_screen_dim
 
 # -----------------------------------------------------------------------------
-# Loading page: title, status label, progress bar
+# Loading page: status label and progress bar
 # -----------------------------------------------------------------------------
 lvgl:
   pages:
@@ -69,12 +69,6 @@ lvgl:
               flex_align_cross: center
               pad_row: 40
             widgets:
-              - label:
-                  text: "Starting up"
-                  text_font: noto_400_46_font
-                  text_color: 0xFFFFFF
-                  width: 700
-                  text_align: center
               - label:
                   id: loading_status_label
                   text: "Booting"

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -279,7 +279,7 @@ lvgl:
             id: slideshow_navigation_feedback
             align: RIGHT_MID
             x: -36
-            width: 230
+            width: 82
             height: 82
             radius: 41
             bg_color: 0x000000
@@ -295,9 +295,9 @@ lvgl:
               - label:
                   id: slideshow_navigation_feedback_label
                   align: CENTER
-                  text: "Next  >"
+                  text: $icon_chevron_right
                   text_color: 0xFFFFFF
-                  text_font: noto_400_30_font
+                  text_font: icon_font_setup
         - obj:
             id: connection_failed_overlay
             align: CENTER
@@ -559,10 +559,10 @@ script:
     then:
       - lambda: |-
           if (direction > 0) {
-            lv_label_set_text(id(slideshow_navigation_feedback_label), "Next  >");
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "${icon_chevron_right}");
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_RIGHT_MID, -36, 0);
           } else {
-            lv_label_set_text(id(slideshow_navigation_feedback_label), "<  Previous");
+            lv_label_set_text(id(slideshow_navigation_feedback_label), "${icon_chevron_left}");
             lv_obj_align(id(slideshow_navigation_feedback), LV_ALIGN_LEFT_MID, 36, 0);
           }
           lv_obj_clear_flag(id(slideshow_navigation_feedback), LV_OBJ_FLAG_HIDDEN);

--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -284,9 +284,7 @@ lvgl:
             radius: 41
             bg_color: 0x000000
             bg_opa: 65%
-            border_width: 2
-            border_color: 0xFFFFFF
-            border_opa: 35%
+            border_width: 0
             pad_all: 0
             scrollable: false
             clickable: false

--- a/tests/web_module_tests.js
+++ b/tests/web_module_tests.js
@@ -16,6 +16,14 @@ const slideshowScreenSource = fs.readFileSync(
   path.join(root, "devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml"),
   "utf8"
 );
+const loadingScreenSource = fs.readFileSync(
+  path.join(root, "devices/guition-esp32-p4-jc8012p4a1/device/screen_loading.yaml"),
+  "utf8"
+);
+const iconSource = fs.readFileSync(
+  path.join(root, "devices/guition-esp32-p4-jc8012p4a1/assets/icons.yaml"),
+  "utf8"
+);
 const displayDeviceSources = [
   "devices/guition-esp32-p4-jc8012p4a1/device/device.yaml",
   "devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml"
@@ -158,6 +166,24 @@ assert.equal(
   slideshowScreenSource.includes("slideshow_swipe_suppress_tap_until_ms) = 0"),
   false,
   "navigation feedback should not clear swipe tap suppression before release"
+);
+assert.ok(
+  slideshowScreenSource.includes("text_font: icon_font_setup") &&
+    slideshowScreenSource.includes("${icon_chevron_right}") &&
+    slideshowScreenSource.includes("${icon_chevron_left}") &&
+    iconSource.includes('icon_chevron_left: "\\U000F0141"') &&
+    iconSource.includes('icon_chevron_right: "\\U000F0142"'),
+  "slideshow navigation feedback should use icon-only chevrons"
+);
+assert.equal(
+  slideshowScreenSource.includes('"Next  >"') || slideshowScreenSource.includes('"<  Previous"'),
+  false,
+  "slideshow navigation feedback should not display next or previous text"
+);
+assert.equal(
+  loadingScreenSource.includes('text: "Starting up"'),
+  false,
+  "the loading screen should not display a centered startup title"
 );
 displayDeviceSources.forEach((source) => {
   assert.ok(

--- a/tests/web_module_tests.js
+++ b/tests/web_module_tests.js
@@ -180,6 +180,16 @@ assert.equal(
   false,
   "slideshow navigation feedback should not display next or previous text"
 );
+const navigationFeedbackSource = slideshowScreenSource.slice(
+  slideshowScreenSource.indexOf("id: slideshow_navigation_feedback\n"),
+  slideshowScreenSource.indexOf("id: slideshow_navigation_feedback_label\n")
+);
+assert.ok(
+  navigationFeedbackSource.includes("border_width: 0") &&
+    !navigationFeedbackSource.includes("border_color:") &&
+    !navigationFeedbackSource.includes("border_opa:"),
+  "slideshow navigation feedback should not display an outline"
+);
 assert.equal(
   loadingScreenSource.includes('text: "Starting up"'),
   false,


### PR DESCRIPTION
## What changes when merged

- Replace the slideshow swipe feedback text with compact icon-only previous/next chevrons.
- Remove the centered startup title while retaining live startup status and progress.
- Add regression coverage for the icon-only feedback and simplified loading screen.

## Automated checks

- [x] `npm run check:pr` passed
- [x] CI checks are expected to pass

## Device testing

- [ ] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [x] Needs device testing before merge

PR Validation workflow run/artifact: Initial PR validation passed

Firmware artifact (`firmware-test-<device>`): Not produced by the initial path-filtered run

Device tested: Guition ESP32-P4 JC8012P4A1 test display (`192.168.6.106`)

Result/notes: PR commit `2a6fbb1` compiled with ESPHome 2026.7.4 and flashed successfully over OTA. The display rebooted and returned online with 0% packet loss; visual icon/loading-screen confirmation is still pending.

## Notes for reviewers

- Both supported panel revisions share the changed slideshow, loading-screen, and icon sources.
- Local browser validation used repository-local temporary and timezone overlays to accommodate Snap Chromium confinement and the host's missing legacy `Asia/Rangoon` alias.
