### PR TITLE
Pin ESPHome 2026.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ npm ci
 npm run docs:dev
 
 # Compile firmware locally
-docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.7.4 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
-docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.7.4 compile /config/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
+docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.8.2 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.8.2 compile /config/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
 ```
 
 ### In-Development Firmware Features

--- a/docs/install.md
+++ b/docs/install.md
@@ -59,4 +59,4 @@ Choose whether the on-screen clock uses a 24-hour or 12-hour format.
 
 - **Multiple Album, Person, or Tag IDs:** Saving comma-separated UUID lists uses a POST body so long lists no longer hit **414 URI Too Long**. Album IDs, Person IDs, and Tag IDs are still limited to **255 characters** each; see [Photo Sources](/photo-sources#album-person-and-tag-id-limits).
 - **Photo date filters:** The web UI now supports fixed date ranges and rolling ranges such as the last 6 months or last 2 years. See [Photo Sources](/photo-sources#date-filtering).
-- **ESPHome 2026.7:** Current local builds use ESPHome `2026.7.4`; manual builds also include compatibility fixes for ESPHome 2026.3, 2026.4, and 2026.7 LVGL changes.
+- **ESPHome 2026.8:** Current local builds use ESPHome `2026.8.2`; manual builds also include compatibility fixes for ESPHome 2026.3, 2026.4, and 2026.7 LVGL changes.

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -75,7 +75,7 @@ api:
 Add a unique 32-byte base64 key as `api_encryption_key` in `secrets.yaml`; generate one with `openssl rand -base64 32`. Never reuse the Immich API key here. Changing this value later requires reconfiguring the ESPHome integration in Home Assistant.
 
 ::: info ESPHome version
-Current local builds use ESPHome `2026.7.4`. The shared configuration includes compatibility fixes for ESPHome 2026.3, 2026.4, and 2026.7 LVGL changes.
+Current local builds use ESPHome `2026.8.2`. The shared configuration includes compatibility fixes for ESPHome 2026.3, 2026.4, and 2026.7 LVGL changes.
 :::
 
 ## Substitutions

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -92,7 +92,7 @@ RAM, and binary budgets, and uploads a `firmware-test-<device>` artifact contain
 To run the same factory compile locally with Docker:
 
 ```sh
-docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.7.4 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+docker run --rm -v "${PWD}:/config" ghcr.io/esphome/esphome:2026.8.2 compile /config/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
 ```
 
 Use a full compile before firmware releases, after changing ESPHome YAML, after changing C++ code that is not covered by the host-side helper tests, and whenever you want a branch firmware build to flash to a test display.

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -1749,5 +1749,5 @@
   "esphome_docker_image": "ghcr.io/esphome/esphome",
   "esphome_config_mount": "/config",
   "esphome_docker_remove_container": true,
-  "esphome_version": "2026.7.4"
+  "esphome_version": "2026.8.2"
 }

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1756,7 +1756,7 @@
     "esphome_docker_image": "ghcr.io/esphome/esphome",
     "esphome_config_mount": "/config",
     "esphome_docker_remove_container": true,
-    "esphome_version": "2026.7.4"
+    "esphome_version": "2026.8.2"
   },
   "devices": [
     {


### PR DESCRIPTION
## What changes when merged

- Pin local and CI firmware builds to ESPHome 2026.8.2.
- Keep generated product metadata and build documentation aligned with the canonical version.

## Automated checks

- [x] `npm run check:pr` passed
- [x] CI checks are expected to pass

## Device testing

- [ ] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [x] Local development build flashed to device
- [ ] Needs device testing before merge

PR Validation workflow run/artifact: Not run

Firmware artifact (`firmware-test-<device>`): Not generated; local `dev.yaml` build used

Device tested: Guition ESP32-P4 JC8012P4A1 at `192.168.6.106`

Result/notes: ESPHome 2026.8.2 compiled successfully, uploaded over OTA successfully, and the display returned online after reboot.

## Notes for reviewers

- The repository's complete `npm run check:pr` validation passed.
- The original Guition device variant was compiled and flashed; the v2 variant was not compiled or device-tested locally.
