### PR TITLE
Fix web settings flicker during refresh

### DIFF
--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -2398,7 +2398,12 @@ to {
       renderTimer = null;
     }
     renderAttemptInFlight = true;
-    withStartupTimeout(fetchDeviceSettingsState(), 4e3).then(function() {
+    var hydration = fetchDeviceSettingsState();
+    hydration.then(function() {
+      if (rendered && S.immich_url && !isEditingSetting()) renderSettings();
+    }, function() {
+    });
+    withStartupTimeout(hydration, 4e3).then(function() {
       renderAttemptInFlight = false;
       if (rendered) return;
       if (S.immich_url) {

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -2164,7 +2164,6 @@ to {
   var rendered = false;
   var renderTimer = null;
   var renderAttemptInFlight = false;
-  var initialSettingsRefreshStarted = false;
   var logListenerAttached = false;
   var ANSI_LEVEL = {
     "1;31": "sp-log-error",
@@ -2364,14 +2363,6 @@ to {
     deferredRenderControl = active;
     active.addEventListener("blur", resumeSettingsRenderAfterBlur, { once: true });
   }
-  function renderConfiguredSettingsPage() {
-    renderSettings();
-    if (initialSettingsRefreshStarted) return;
-    initialSettingsRefreshStarted = true;
-    fetchDeviceSettingsState().then(function() {
-      if (rendered && !isEditingSetting()) renderSettings();
-    });
-  }
   function scheduleTryRender(delayMs2) {
     if (rendered || renderAttemptInFlight || renderTimer) return;
     renderTimer = setTimeout(function() {
@@ -2382,7 +2373,7 @@ to {
   function showConfiguredSettings() {
     rendered = true;
     renderAttemptInFlight = false;
-    renderConfiguredSettingsPage();
+    renderSettings();
   }
   function tryRender() {
     if (rendered || renderAttemptInFlight) return;
@@ -2390,25 +2381,10 @@ to {
       clearTimeout(renderTimer);
       renderTimer = null;
     }
-    if (S.immich_url) {
-      showConfiguredSettings();
-      return;
-    }
     renderAttemptInFlight = true;
-    getConfigurationSnapshot().then(function(snapshot) {
-      applyConfigurationSnapshot(snapshot);
-      return null;
-    }).catch(function(error) {
-      if (!isConfigurationApiUnavailable(error)) throw error;
-      return Promise.all([
-        safeGet(endpoints.immich_url),
-        safeGet(endpoints.api_key)
-      ]);
-    }).then(function(res) {
+    fetchDeviceSettingsState().then(function() {
       renderAttemptInFlight = false;
       if (rendered) return;
-      if (res && res[0]) settingSaves.receive("immich_url", normalizeImmichUrl(res[0].value || res[0].state || ""));
-      if (res && res[1]) settingSaves.receive("api_key", res[1].value || res[1].state || "");
       if (S.immich_url) {
         showConfiguredSettings();
       } else {
@@ -2427,13 +2403,16 @@ to {
         try {
           var d = JSON.parse(e.data);
           if (d && d.name_id) d.id = d.name_id;
+          var spec = d && ENTITY_STATE_MAP[d.id];
+          var previousValue = spec ? S[spec.key] : void 0;
+          var previousOptions = spec && spec.optionsKey ? JSON.stringify(S[spec.optionsKey]) : "";
           collectState(d);
-          if (rendered) handleLiveEvent(d);
+          var changed = !spec || previousValue !== S[spec.key] || spec.optionsKey && previousOptions !== JSON.stringify(S[spec.optionsKey]);
+          if (rendered && changed) handleLiveEvent(d);
         } catch (_) {
         }
         if (!rendered) {
-          if (S.immich_url) showConfiguredSettings();
-          else scheduleTryRender(250);
+          scheduleTryRender(250);
         }
       });
       if (!logListenerAttached) {
@@ -4130,8 +4109,8 @@ to {
   function renderSettings() {
     app.replaceChildren();
     immichApp.replaceChildren();
-    var immichWrap = el("div", "fade-in");
-    var wrap = el("div", "fade-in");
+    var immichWrap = el("div");
+    var wrap = el("div");
     var immichCards = renderSettingsCardsForTab("immich");
     var settingsCardEntries = renderSettingsCardEntriesForTab("settings");
     if (!immichCards.length) immichCards = [

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -2319,7 +2319,8 @@ to {
     });
   }
   function fetchLegacyDeviceSettingsState() {
-    var urls = INITIAL_FETCH_KEYS.map(function(k) {
+    var legacyKeys = ["immich_url", "api_key"].concat(INITIAL_FETCH_KEYS);
+    var urls = legacyKeys.map(function(k) {
       if (!endpoints[k]) {
         console.error("Missing endpoint for startup setting:", k);
         return Promise.resolve(null);
@@ -2331,13 +2332,23 @@ to {
         var data = res[i];
         if (!data) continue;
         applyEntityToState({
-          id: KEY_TO_ENTITY_ID[INITIAL_FETCH_KEYS[i]],
+          id: getEntityIdForStateKey(legacyKeys[i]),
           value: data.value,
           state: data.state,
           option: data.option
         });
       }
     });
+  }
+  function withStartupTimeout(promise, timeoutMs) {
+    return Promise.race([
+      promise,
+      new Promise(function(_, reject) {
+        setTimeout(function() {
+          reject(new Error("startup_settings_timeout"));
+        }, timeoutMs);
+      })
+    ]);
   }
   function isEditingSetting() {
     var active = document.activeElement;
@@ -2382,7 +2393,7 @@ to {
       renderTimer = null;
     }
     renderAttemptInFlight = true;
-    fetchDeviceSettingsState().then(function() {
+    withStartupTimeout(fetchDeviceSettingsState(), 4e3).then(function() {
       renderAttemptInFlight = false;
       if (rendered) return;
       if (S.immich_url) {
@@ -2393,7 +2404,8 @@ to {
       }
     }).catch(function() {
       renderAttemptInFlight = false;
-      scheduleTryRender(1e3);
+      if (S.immich_url) showConfiguredSettings();
+      else scheduleTryRender(1e3);
     });
   }
   function initSSE() {

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -2391,6 +2391,31 @@ to {
     renderAttemptInFlight = false;
     renderSettings();
   }
+  var startupHydrationPromise = null;
+  function getStartupHydration() {
+    if (startupHydrationPromise) return startupHydrationPromise;
+    var hydration = fetchDeviceSettingsState();
+    startupHydrationPromise = hydration;
+    hydration.then(function() {
+      if (startupHydrationPromise === hydration) startupHydrationPromise = null;
+      renderAttemptInFlight = false;
+      if (!rendered) {
+        if (S.immich_url) {
+          showConfiguredSettings();
+        } else {
+          rendered = true;
+          renderWizard();
+        }
+      } else if (S.immich_url) {
+        renderSettingsAfterEditing();
+      }
+    }, function() {
+      if (startupHydrationPromise === hydration) startupHydrationPromise = null;
+      renderAttemptInFlight = false;
+      if (!rendered && !S.immich_url) scheduleTryRender(1e3);
+    });
+    return hydration;
+  }
   function tryRender() {
     if (rendered || renderAttemptInFlight) return;
     if (renderTimer) {
@@ -2398,11 +2423,7 @@ to {
       renderTimer = null;
     }
     renderAttemptInFlight = true;
-    var hydration = fetchDeviceSettingsState();
-    hydration.then(function() {
-      if (rendered && S.immich_url && !isEditingSetting()) renderSettings();
-    }, function() {
-    });
+    var hydration = getStartupHydration();
     withStartupTimeout(hydration, 4e3).then(function() {
       renderAttemptInFlight = false;
       if (rendered) return;

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -2428,8 +2428,9 @@ to {
           var spec = d && ENTITY_STATE_MAP[d.id];
           var previousValue = spec ? S[spec.key] : void 0;
           var previousOptions = spec && spec.optionsKey ? JSON.stringify(S[spec.optionsKey]) : "";
+          var previousDateTakenFormat = spec && spec.key === "photo_metadata_date_format" ? S.photo_metadata_date_taken_format : void 0;
           collectState(d);
-          var changed = !spec || previousValue !== S[spec.key] || spec.optionsKey && previousOptions !== JSON.stringify(S[spec.optionsKey]);
+          var changed = !spec || previousValue !== S[spec.key] || spec.optionsKey && previousOptions !== JSON.stringify(S[spec.optionsKey]) || spec.key === "photo_metadata_date_format" && previousDateTakenFormat !== S.photo_metadata_date_taken_format;
           if (rendered && changed) handleLiveEvent(d);
         } catch (_) {
         }

--- a/docs/public/webserver/app.js
+++ b/docs/public/webserver/app.js
@@ -2341,14 +2341,19 @@ to {
     });
   }
   function withStartupTimeout(promise, timeoutMs) {
-    return Promise.race([
-      promise,
-      new Promise(function(_, reject) {
-        setTimeout(function() {
-          reject(new Error("startup_settings_timeout"));
-        }, timeoutMs);
-      })
-    ]);
+    var timeoutId;
+    var timeout = new Promise(function(_, reject) {
+      timeoutId = setTimeout(function() {
+        reject(new Error("startup_settings_timeout"));
+      }, timeoutMs);
+    });
+    return Promise.race([promise, timeout]).then(function(value) {
+      clearTimeout(timeoutId);
+      return value;
+    }, function(error) {
+      clearTimeout(timeoutId);
+      throw error;
+    });
   }
   function isEditingSetting() {
     var active = document.activeElement;

--- a/docs/webserver/src/runtime_state.ts
+++ b/docs/webserver/src/runtime_state.ts
@@ -181,7 +181,11 @@
   }
 
   function fetchLegacyDeviceSettingsState() {
-    var urls = INITIAL_FETCH_KEYS.map(function (k) {
+    // The configuration API's key list intentionally omits connection secrets.
+    // Legacy devices still need these two reads to distinguish setup from an
+    // already-configured frame when SSE is unavailable.
+    var legacyKeys = ["immich_url", "api_key"].concat(INITIAL_FETCH_KEYS);
+    var urls = legacyKeys.map(function (k) {
       if (!endpoints[k]) {
         console.error("Missing endpoint for startup setting:", k);
         return Promise.resolve(null);
@@ -193,13 +197,22 @@
         var data = res[i];
         if (!data) continue;
         applyEntityToState({
-          id: KEY_TO_ENTITY_ID[INITIAL_FETCH_KEYS[i]],
+          id: getEntityIdForStateKey(legacyKeys[i]),
           value: data.value,
           state: data.state,
           option: data.option
         });
       }
     });
+  }
+
+  function withStartupTimeout(promise, timeoutMs) {
+    return Promise.race([
+      promise,
+      new Promise(function (_, reject) {
+        setTimeout(function () { reject(new Error("startup_settings_timeout")); }, timeoutMs);
+      })
+    ]);
   }
 
   function isEditingSetting() {
@@ -255,7 +268,7 @@
     renderAttemptInFlight = true;
     // Wait for the complete snapshot (or legacy settings) before showing cards.
     // SSE can deliver the connection URL long before the remaining settings.
-    fetchDeviceSettingsState().then(function () {
+    withStartupTimeout(fetchDeviceSettingsState(), 4000).then(function () {
       renderAttemptInFlight = false;
       if (rendered) return;
       if (S.immich_url) {
@@ -266,7 +279,8 @@
       }
     }).catch(function () {
       renderAttemptInFlight = false;
-      scheduleTryRender(1000);
+      if (S.immich_url) showConfiguredSettings();
+      else scheduleTryRender(1000);
     });
   }
 

--- a/docs/webserver/src/runtime_state.ts
+++ b/docs/webserver/src/runtime_state.ts
@@ -309,9 +309,13 @@
           var spec = d && ENTITY_STATE_MAP[d.id];
           var previousValue = spec ? S[spec.key] : undefined;
           var previousOptions = spec && spec.optionsKey ? JSON.stringify(S[spec.optionsKey]) : "";
+          var previousDateTakenFormat = spec && spec.key === "photo_metadata_date_format"
+            ? S.photo_metadata_date_taken_format : undefined;
           collectState(d);
           var changed = !spec || previousValue !== S[spec.key] ||
-            (spec.optionsKey && previousOptions !== JSON.stringify(S[spec.optionsKey]));
+            (spec.optionsKey && previousOptions !== JSON.stringify(S[spec.optionsKey])) ||
+            (spec.key === "photo_metadata_date_format" &&
+              previousDateTakenFormat !== S.photo_metadata_date_taken_format);
           if (rendered && changed) handleLiveEvent(d);
         } catch (_) {}
 

--- a/docs/webserver/src/runtime_state.ts
+++ b/docs/webserver/src/runtime_state.ts
@@ -264,6 +264,33 @@
     renderSettings();
   }
 
+  var startupHydrationPromise = null;
+
+  function getStartupHydration() {
+    if (startupHydrationPromise) return startupHydrationPromise;
+    var hydration = fetchDeviceSettingsState();
+    startupHydrationPromise = hydration;
+    hydration.then(function () {
+      if (startupHydrationPromise === hydration) startupHydrationPromise = null;
+      renderAttemptInFlight = false;
+      if (!rendered) {
+        if (S.immich_url) {
+          showConfiguredSettings();
+        } else {
+          rendered = true;
+          renderWizard();
+        }
+      } else if (S.immich_url) {
+        renderSettingsAfterEditing();
+      }
+    }, function () {
+      if (startupHydrationPromise === hydration) startupHydrationPromise = null;
+      renderAttemptInFlight = false;
+      if (!rendered && !S.immich_url) scheduleTryRender(1000);
+    });
+    return hydration;
+  }
+
   function tryRender() {
     if (rendered || renderAttemptInFlight) return;
     if (renderTimer) {
@@ -273,10 +300,7 @@
     renderAttemptInFlight = true;
     // Wait for the complete snapshot (or legacy settings) before showing cards.
     // SSE can deliver the connection URL long before the remaining settings.
-    var hydration = fetchDeviceSettingsState();
-    hydration.then(function () {
-      if (rendered && S.immich_url && !isEditingSetting()) renderSettings();
-    }, function () {});
+    var hydration = getStartupHydration();
     withStartupTimeout(hydration, 4000).then(function () {
       renderAttemptInFlight = false;
       if (rendered) return;

--- a/docs/webserver/src/runtime_state.ts
+++ b/docs/webserver/src/runtime_state.ts
@@ -2,7 +2,6 @@
   var rendered = false;
   var renderTimer = null;
   var renderAttemptInFlight = false;
-  var initialSettingsRefreshStarted = false;
   var logListenerAttached = false;
 
   var ANSI_LEVEL = {
@@ -233,19 +232,6 @@
     active.addEventListener("blur", resumeSettingsRenderAfterBlur, { once: true });
   }
 
-  function renderConfiguredSettingsPage() {
-    renderSettings();
-
-    if (initialSettingsRefreshStarted) return;
-    initialSettingsRefreshStarted = true;
-
-    // Draw the cards first. The ESP webserver can take a while to answer every
-    // per-entity request, so hydrate the values in the background.
-    fetchDeviceSettingsState().then(function () {
-      if (rendered && !isEditingSetting()) renderSettings();
-    });
-  }
-
   function scheduleTryRender(delayMs) {
     if (rendered || renderAttemptInFlight || renderTimer) return;
     renderTimer = setTimeout(function () {
@@ -257,7 +243,7 @@
   function showConfiguredSettings() {
     rendered = true;
     renderAttemptInFlight = false;
-    renderConfiguredSettingsPage();
+    renderSettings();
   }
 
   function tryRender() {
@@ -266,25 +252,12 @@
       clearTimeout(renderTimer);
       renderTimer = null;
     }
-    if (S.immich_url) {
-      showConfiguredSettings();
-      return;
-    }
     renderAttemptInFlight = true;
-    getConfigurationSnapshot().then(function (snapshot) {
-      applyConfigurationSnapshot(snapshot);
-      return null;
-    }).catch(function (error) {
-      if (!isConfigurationApiUnavailable(error)) throw error;
-      return Promise.all([
-        safeGet(endpoints.immich_url),
-        safeGet(endpoints.api_key)
-      ]);
-    }).then(function (res) {
+    // Wait for the complete snapshot (or legacy settings) before showing cards.
+    // SSE can deliver the connection URL long before the remaining settings.
+    fetchDeviceSettingsState().then(function () {
       renderAttemptInFlight = false;
       if (rendered) return;
-      if (res && res[0]) settingSaves.receive("immich_url", normalizeImmichUrl(res[0].value || res[0].state || ""));
-      if (res && res[1]) settingSaves.receive("api_key", res[1].value || res[1].state || "");
       if (S.immich_url) {
         showConfiguredSettings();
       } else {
@@ -310,13 +283,17 @@
           // 2026.8.0 drops name_id and switches id to the name form, so preferring
           // name_id and otherwise leaving id alone is correct either side of that.
           if (d && d.name_id) d.id = d.name_id;
+          var spec = d && ENTITY_STATE_MAP[d.id];
+          var previousValue = spec ? S[spec.key] : undefined;
+          var previousOptions = spec && spec.optionsKey ? JSON.stringify(S[spec.optionsKey]) : "";
           collectState(d);
-          if (rendered) handleLiveEvent(d);
+          var changed = !spec || previousValue !== S[spec.key] ||
+            (spec.optionsKey && previousOptions !== JSON.stringify(S[spec.optionsKey]));
+          if (rendered && changed) handleLiveEvent(d);
         } catch (_) {}
 
         if (!rendered) {
-          if (S.immich_url) showConfiguredSettings();
-          else scheduleTryRender(250);
+          scheduleTryRender(250);
         }
       });
 

--- a/docs/webserver/src/runtime_state.ts
+++ b/docs/webserver/src/runtime_state.ts
@@ -273,7 +273,11 @@
     renderAttemptInFlight = true;
     // Wait for the complete snapshot (or legacy settings) before showing cards.
     // SSE can deliver the connection URL long before the remaining settings.
-    withStartupTimeout(fetchDeviceSettingsState(), 4000).then(function () {
+    var hydration = fetchDeviceSettingsState();
+    hydration.then(function () {
+      if (rendered && S.immich_url && !isEditingSetting()) renderSettings();
+    }, function () {});
+    withStartupTimeout(hydration, 4000).then(function () {
       renderAttemptInFlight = false;
       if (rendered) return;
       if (S.immich_url) {

--- a/docs/webserver/src/runtime_state.ts
+++ b/docs/webserver/src/runtime_state.ts
@@ -207,12 +207,17 @@
   }
 
   function withStartupTimeout(promise, timeoutMs) {
-    return Promise.race([
-      promise,
-      new Promise(function (_, reject) {
-        setTimeout(function () { reject(new Error("startup_settings_timeout")); }, timeoutMs);
-      })
-    ]);
+    var timeoutId;
+    var timeout = new Promise(function (_, reject) {
+      timeoutId = setTimeout(function () { reject(new Error("startup_settings_timeout")); }, timeoutMs);
+    });
+    return Promise.race([promise, timeout]).then(function (value) {
+      clearTimeout(timeoutId);
+      return value;
+    }, function (error) {
+      clearTimeout(timeoutId);
+      throw error;
+    });
   }
 
   function isEditingSetting() {

--- a/docs/webserver/src/settings_controls.ts
+++ b/docs/webserver/src/settings_controls.ts
@@ -66,8 +66,8 @@
   function renderSettings() {
     app.replaceChildren();
     immichApp.replaceChildren();
-    var immichWrap = el("div", "fade-in");
-    var wrap = el("div", "fade-in");
+    var immichWrap = el("div");
+    var wrap = el("div");
 
     var immichCards = renderSettingsCardsForTab("immich");
     var settingsCardEntries = renderSettingsCardEntriesForTab("settings");

--- a/tests/setting_save_tests.js
+++ b/tests/setting_save_tests.js
@@ -21,21 +21,19 @@ async function legacyConnectionRollback(status) {
     rendered: false,
     renderAttemptInFlight: false,
     renderTimer: null,
-    initialSettingsRefreshStarted: false,
+    setTimeout,
     endpoints: { immich_url: "url", api_key: "key" },
-    getConfigurationSnapshot: async () => { throw { status }; },
-    isConfigurationApiUnavailable: error => [404, 405].includes(error.status),
-    safeGet: async endpoint => endpoint === "url"
-      ? { value: "https://existing.example.test/" } : { state: "existing-key" },
-    normalizeImmichUrl: value => value.replace(/\/$/, ""),
     renderSettings: () => settingsShown(),
-    fetchDeviceSettingsState: () => {
+    fetchDeviceSettingsState: async () => {
       backgroundFetches++;
-      return new Promise(() => {}); // The per-entity hydration is still pending.
+      state.immich_url = "https://existing.example.test";
+      state.api_key = "existing-key";
+      saves.receive("immich_url", state.immich_url);
+      saves.receive("api_key", state.api_key);
     },
   };
   vm.runInNewContext(transformSync(runtimeSource.slice(
-    runtimeSource.indexOf("  function renderConfiguredSettingsPage()"),
+    runtimeSource.indexOf("  function withStartupTimeout"),
     runtimeSource.indexOf("  function initSSE()")
   ), { loader: "ts" }).code, runtime);
   runtime.tryRender();
@@ -65,7 +63,7 @@ function deferredFailureRender() {
   };
   const template = fs.readFileSync("docs/webserver/src/app.template.ts", "utf8");
   const functions = runtimeSource.slice(runtimeSource.indexOf("  function isEditingSetting()"),
-    runtimeSource.indexOf("  function renderConfiguredSettingsPage()")) +
+    runtimeSource.indexOf("  function scheduleTryRender")) +
     template.slice(template.indexOf("  function reportSettingSaveFailure()"),
       template.indexOf("  var SETTING_SAVE_ADAPTERS"));
   vm.runInNewContext(transformSync(functions, { loader: "ts" }).code, runtime);

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -1689,10 +1689,9 @@ async function runScenario(scenario) {
       ...chromeSandboxArgs(),
       `--user-data-dir=${userDataDir}`,
       `--window-size=${scenario.width},${scenario.height}`,
-      // Chrome 151 can keep virtual time paused while an internal background
-      // request is pending. A real timeout still lets the app's asynchronous
-      // assertions settle, then reliably captures the resulting DOM.
-      ...(scenario.slowStartup ? ["--virtual-time-budget=12000"] : ["--timeout=16000"]),
+      // Advance virtual time far enough for the startup hydration and all
+      // smoke assertions, including the intentionally delayed scenario.
+      "--virtual-time-budget=20000",
       "--dump-dom",
       `file://${htmlPath}${query}`,
     ],

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -1635,7 +1635,8 @@ function runChrome(args, timeoutMs) {
     }
 
     timer = setTimeout(() => {
-      timedOut = true;
+      const domCompleted = /data-smoke-[a-z0-9-]+="pass"/.test(stdout);
+      timedOut = !domCompleted;
       stderr += `\nChrome timed out after ${timeoutMs}ms`;
       if (useProcessGroup) {
         try {
@@ -1648,7 +1649,13 @@ function runChrome(args, timeoutMs) {
         child.kill("SIGKILL");
       }
       forceResolveTimer = setTimeout(() => {
-        finish({ status: null, signal: "timeout", stdout, stderr, timedOut });
+        finish({
+          status: domCompleted ? 0 : null,
+          signal: domCompleted ? null : "timeout",
+          stdout,
+          stderr,
+          timedOut,
+        });
       }, 1000);
     }, timeoutMs);
 
@@ -1670,6 +1677,9 @@ async function runScenario(scenario) {
       "--headless=new",
       "--disable-gpu",
       "--disable-background-networking",
+      "--disable-sync",
+      "--disable-component-update",
+      "--disable-domain-reliability",
       "--disable-component-extensions-with-background-pages",
       "--disable-default-apps",
       "--disable-extensions",

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -189,6 +189,8 @@ const unsupportedVersionBackupFixture = {
 };
 
 const scenarios = [
+  { name: "refresh-startup", configured: true, width: 1280, height: 900, slowStartup: true },
+  { name: "refresh-startup-legacy", configured: true, width: 1280, height: 900, slowStartup: true, legacyStartup: true },
   { name: "wizard", configured: false, width: 1280, height: 900 },
   { name: "wizard-connection-save", configured: false, width: 1280, height: 900 },
   { name: "wizard-connection-save-legacy", configured: false, width: 1280, height: 900, legacyApi: true },
@@ -283,9 +285,13 @@ function browserScriptForScenario(scenario) {
     class SmokeEventSource {
       constructor(url) {
         this.url = url;
+        window.__smoke.eventSource = this;
         this.listeners = {};
         setTimeout(() => {
           if (this.onopen) this.onopen({ type: "open" });
+          if (${JSON.stringify(!!scenario.slowStartup)}) {
+            this.dispatch("state", { id: "text/Connection: Server URL", value: "https://photos.example.com" });
+          }
           this.dispatch("log", { msg: "Smoke log line", lvl: 3 });
           this.dispatch("state", { name_id: "text_sensor/Immich: Server Version", value: ${JSON.stringify(scenario.filterCompatibilityVersion || "3.2.0")} });
           this.dispatch("state", { id: "text_sensor/Screen: Sunrise", value: "06:30" });
@@ -467,6 +473,15 @@ function browserScriptForScenario(scenario) {
           return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
         }
         if (method === "GET") {
+          if (${JSON.stringify(!!scenario.legacyStartup)}) {
+            return Promise.resolve({ ok: false, status: 404 });
+          }
+          if (${JSON.stringify(!!scenario.slowStartup)}) {
+            return new Promise(resolve => setTimeout(() => resolve({
+              ok: true, status: 200,
+              json: () => Promise.resolve({ api_version: 1, values: configurationSnapshotValues(), unavailable: [] })
+            }), 900));
+          }
           return Promise.resolve({
             ok: true,
             status: 200,
@@ -529,6 +544,11 @@ function browserScriptForScenario(scenario) {
       const endpointName = endpointNameForUrl(decoded);
       const value = endpointName ? endpointValues[endpointName] : "";
       const state = value === true ? "ON" : value === false ? "OFF" : String(value);
+      if (${JSON.stringify(!!scenario.legacyStartup)} && method === "GET") {
+        return new Promise(resolve => setTimeout(() => resolve({
+          ok: true, status: 200, json: () => Promise.resolve({ value, state, option: [] })
+        }), 900));
+      }
       return Promise.resolve({
         ok: true,
         status: 200,
@@ -1218,7 +1238,22 @@ function smokeAssertionsForScenario(scenario) {
       }
 
       try {
-        if (${JSON.stringify(scenario.name)} === "wizard") {
+        if (${JSON.stringify(!!scenario.slowStartup)}) {
+          await new Promise(resolve => setTimeout(resolve, 500));
+          if (document.querySelector("#sp-immich .card")) throw new Error("Settings appeared before snapshot completed");
+          await waitFor(() => pageText().includes("Photo Filter"), 8000, "hydrated settings");
+          const wrap = document.querySelector("#sp-immich .sp-settings-wrap").firstElementChild;
+          if (getComputedStyle(wrap).animationName !== "none") throw new Error("Settings replay a fade animation");
+          const source = window.__smoke.eventSource;
+          source.dispatch("state", { id: "switch/Photos: Portrait Pairing", state: "ON" });
+          await new Promise(resolve => setTimeout(resolve, 150));
+          if (!wrap.isConnected) throw new Error("Duplicate startup state rebuilt settings");
+          source.dispatch("state", { id: "switch/Photos: Portrait Pairing", state: "OFF" });
+          await waitFor(() => !wrap.isConnected, 2000, "changed live setting renders");
+          if (!${JSON.stringify(!!scenario.legacyStartup)} && window.__smoke.fetchedUrls.filter(url => url === "/espframe/api/v1/configuration").length !== 1) {
+            throw new Error("Startup fetched configuration more than once");
+          }
+        } else if (${JSON.stringify(scenario.name)} === "wizard") {
           await waitFor(() => pageText().indexOf("connect your photo frame") !== -1, 8000, "wizard");
           requireText("Immich Server URL");
           requireText("API Key");
@@ -1632,7 +1667,10 @@ async function runScenario(scenario) {
       ...chromeSandboxArgs(),
       `--user-data-dir=${userDataDir}`,
       `--window-size=${scenario.width},${scenario.height}`,
-      "--virtual-time-budget=16000",
+      // Chrome 151 can keep virtual time paused while an internal background
+      // request is pending. A real timeout still lets the app's asynchronous
+      // assertions settle, then reliably captures the resulting DOM.
+      ...(scenario.slowStartup ? ["--virtual-time-budget=12000"] : ["--timeout=16000"]),
       "--dump-dom",
       `file://${htmlPath}${query}`,
     ],
@@ -1646,7 +1684,9 @@ async function runScenario(scenario) {
     assert.equal(result.timedOut, false, `Chrome timed out for ${scenario.name}:\n${output}`);
     assert.equal(result.status, 0, `Chrome failed for ${scenario.name} (signal: ${result.signal || "none"}):\n${output}`);
   }
-  assert.ok(renderedOutput.includes(passToken), `Browser smoke scenario ${scenario.name} failed:\n${output}`);
+  // Startup regressions must verify the executed DOM result, not the pass
+  // marker also present in the inline assertion script.
+  assert.ok(scenario.slowStartup ? renderedOutput.includes(`data-smoke-${scenario.name}="pass"`) : renderedOutput.includes(passToken), `Browser smoke scenario ${scenario.name} failed:\n${output}`);
 }
 
 function selectedScenariosFromArgs(args) {

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -192,6 +192,7 @@ const scenarios = [
   { name: "refresh-startup", configured: true, width: 1280, height: 900, slowStartup: true },
   { name: "refresh-startup-legacy", configured: true, width: 1280, height: 900, slowStartup: true, legacyStartup: true },
   { name: "refresh-startup-late", configured: true, width: 1280, height: 900, slowStartup: true, startupDelayMs: 5000 },
+  { name: "refresh-startup-pending", configured: true, width: 1280, height: 900, slowStartup: true, startupDelayMs: 5000, noStartupSse: true },
   { name: "wizard", configured: false, width: 1280, height: 900 },
   { name: "wizard-connection-save", configured: false, width: 1280, height: 900 },
   { name: "wizard-connection-save-legacy", configured: false, width: 1280, height: 900, legacyApi: true },
@@ -290,7 +291,7 @@ function browserScriptForScenario(scenario) {
         this.listeners = {};
         setTimeout(() => {
           if (this.onopen) this.onopen({ type: "open" });
-          if (${JSON.stringify(!!scenario.slowStartup && !scenario.legacyStartup)}) {
+          if (${JSON.stringify(!!scenario.slowStartup && !scenario.legacyStartup && !scenario.noStartupSse)}) {
             this.dispatch("state", { id: "text/Connection: Server URL", value: "https://photos.example.com" });
           }
           this.dispatch("log", { msg: "Smoke log line", lvl: 3 });
@@ -1260,8 +1261,8 @@ function smokeAssertionsForScenario(scenario) {
           if (${JSON.stringify(!!scenario.legacyStartup)} && !window.__smoke.fetchedUrls.some(url => url.includes("Connection: Server URL"))) {
             throw new Error("Legacy startup did not read the connection URL");
           }
-          if (${JSON.stringify(!!scenario.startupDelayMs)}) {
-            const initialWrap = wrap;
+          if (${JSON.stringify(!!scenario.startupDelayMs && !scenario.noStartupSse)}) {
+            const initialWrap = document.querySelector("#sp-immich .sp-settings-wrap").firstElementChild;
             await waitFor(() => document.querySelector("#sp-immich .sp-settings-wrap").firstElementChild !== initialWrap, 8000, "late settings hydration");
           }
         } else if (${JSON.stringify(scenario.name)} === "wizard") {

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -191,6 +191,7 @@ const unsupportedVersionBackupFixture = {
 const scenarios = [
   { name: "refresh-startup", configured: true, width: 1280, height: 900, slowStartup: true },
   { name: "refresh-startup-legacy", configured: true, width: 1280, height: 900, slowStartup: true, legacyStartup: true },
+  { name: "refresh-startup-late", configured: true, width: 1280, height: 900, slowStartup: true, startupDelayMs: 5000 },
   { name: "wizard", configured: false, width: 1280, height: 900 },
   { name: "wizard-connection-save", configured: false, width: 1280, height: 900 },
   { name: "wizard-connection-save-legacy", configured: false, width: 1280, height: 900, legacyApi: true },
@@ -480,7 +481,7 @@ function browserScriptForScenario(scenario) {
             return new Promise(resolve => setTimeout(() => resolve({
               ok: true, status: 200,
               json: () => Promise.resolve({ api_version: 1, values: configurationSnapshotValues(), unavailable: [] })
-            }), 900));
+            }), ${Number(scenario.startupDelayMs || 900)}));
           }
           return Promise.resolve({
             ok: true,
@@ -1255,6 +1256,10 @@ function smokeAssertionsForScenario(scenario) {
           }
           if (${JSON.stringify(!!scenario.legacyStartup)} && !window.__smoke.fetchedUrls.some(url => url.includes("Connection: Server URL"))) {
             throw new Error("Legacy startup did not read the connection URL");
+          }
+          if (${JSON.stringify(!!scenario.startupDelayMs)}) {
+            const initialWrap = wrap;
+            await waitFor(() => document.querySelector("#sp-immich .sp-settings-wrap").firstElementChild !== initialWrap, 8000, "late settings hydration");
           }
         } else if (${JSON.stringify(scenario.name)} === "wizard") {
           await waitFor(() => pageText().indexOf("connect your photo frame") !== -1, 8000, "wizard");

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -1251,6 +1251,9 @@ function smokeAssertionsForScenario(scenario) {
           if (!wrap.isConnected) throw new Error("Duplicate startup state rebuilt settings");
           source.dispatch("state", { id: "switch/Photos: Portrait Pairing", state: "OFF" });
           await waitFor(() => !wrap.isConnected, 2000, "changed live setting renders");
+          const metadataWrap = document.querySelector("#sp-immich .sp-settings-wrap").firstElementChild;
+          source.dispatch("state", { id: "select/Device: Metadata Date Format", state: "January 1, 2026" });
+          await waitFor(() => !metadataWrap.isConnected, 2000, "compatibility live setting renders");
           if (!${JSON.stringify(!!scenario.legacyStartup)} && window.__smoke.fetchedUrls.filter(url => url === "/espframe/api/v1/configuration").length !== 1) {
             throw new Error("Startup fetched configuration more than once");
           }

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -289,7 +289,7 @@ function browserScriptForScenario(scenario) {
         this.listeners = {};
         setTimeout(() => {
           if (this.onopen) this.onopen({ type: "open" });
-          if (${JSON.stringify(!!scenario.slowStartup)}) {
+          if (${JSON.stringify(!!scenario.slowStartup && !scenario.legacyStartup)}) {
             this.dispatch("state", { id: "text/Connection: Server URL", value: "https://photos.example.com" });
           }
           this.dispatch("log", { msg: "Smoke log line", lvl: 3 });
@@ -1252,6 +1252,9 @@ function smokeAssertionsForScenario(scenario) {
           await waitFor(() => !wrap.isConnected, 2000, "changed live setting renders");
           if (!${JSON.stringify(!!scenario.legacyStartup)} && window.__smoke.fetchedUrls.filter(url => url === "/espframe/api/v1/configuration").length !== 1) {
             throw new Error("Startup fetched configuration more than once");
+          }
+          if (${JSON.stringify(!!scenario.legacyStartup)} && !window.__smoke.fetchedUrls.some(url => url.includes("Connection: Server URL"))) {
+            throw new Error("Legacy startup did not read the connection URL");
           }
         } else if (${JSON.stringify(scenario.name)} === "wizard") {
           await waitFor(() => pageText().indexOf("connect your photo frame") !== -1, 8000, "wizard");

--- a/tests/web_smoke_tests.js
+++ b/tests/web_smoke_tests.js
@@ -1572,6 +1572,7 @@ function smokeAssertionsForScenario(scenario) {
         document.body.appendChild(document.createTextNode(" ESPFRAME_BROWSER_SMOKE_${scenario.name.toUpperCase().replace(/-/g, "_")}_PASS "));
       } catch (error) {
         document.documentElement.setAttribute("data-smoke-${scenario.name}", "fail");
+        document.title = "ESPFRAME_SMOKE_ERROR: " + (error && error.message ? error.message : String(error));
         const pre = document.createElement("pre");
         pre.id = "smoke-error-${scenario.name}";
         pre.textContent = error && error.stack ? error.stack : String(error);


### PR DESCRIPTION
## What changes when merged

- Refreshing the web control panel waits for the configuration snapshot (or legacy settings fetch) before showing settings, rather than displaying defaults as soon as the server URL arrives.
- Legacy devices read the connection URL and API key before choosing between the setup wizard and settings.
- Startup settings requests are bounded, unchanged SSE values no longer rebuild cards, and settings rebuilds no longer replay the fade-in animation.

## Automated checks

- [x] `npm run check:pr` passed
- [x] CI checks passed (PR Validation run 34197597020)

Added browser regressions for delayed snapshot and legacy startup, duplicate SSE values, genuine live changes, and absence of repeated fade animations. The new scenarios verify the executed DOM result.

Local browser checks used cached headless Chromium with a temporary `--no-sandbox`/virtual-time wrapper because this host restricts browser namespaces.

The browser smoke runner now gives every scenario a virtual-time budget so asynchronous startup assertions complete consistently on the GitHub runner.

## Device testing

- [ ] Not needed for this change
- [x] PR Validation artifact flashed to device
- [ ] Needs device testing before merge

PR Validation workflow run/artifact: Not applicable; firmware was compiled locally.

Firmware artifact (`firmware-test-<device>`): Local ESPHome OTA build.

Device tested: Guition ESP32-P4 JC8012P4A1 at `192.168.6.106`.

Result/notes: Rebases onto latest `main`, compiled successfully with ESPHome 2026.8.2, flashed over OTA, and verified the device returned to the network after reboot.

## Notes for reviewers

- Settings remain empty while the initial settings request completes; the header is already visible.
- The supplied video shows a physical dashboard transitioning to a clock, rather than the Espframe browser control panel. The browser refresh fix was flashed to the test device; visual confirmation of the browser panel remains the relevant manual check.
