### PR TITLE
fix(esphome): migrate build flags from platformio options

### DIFF
--- a/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1-v2.factory.yaml
@@ -18,7 +18,7 @@ external_components:
   - source:
       type: local
       path: ../components
-    components: [gsl3680, remote_image, espframe]
+    components: [gsl3680, remote_image, ledc, espframe]
 
 web_server:
   port: 80

--- a/builds/guition-esp32-p4-jc8012p4a1-v2.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1-v2.yaml
@@ -21,7 +21,7 @@ external_components:
   - source:
       type: local
       path: ../components
-    components: [gsl3680, remote_image, espframe]
+    components: [gsl3680, remote_image, ledc, espframe]
 
 wifi:
   ap:

--- a/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.factory.yaml
@@ -20,7 +20,7 @@ external_components:
   - source:
       type: local
       path: ../components
-    components: [gsl3680, remote_image, espframe]
+    components: [gsl3680, remote_image, ledc, espframe]
 
 web_server:
   port: 80

--- a/builds/guition-esp32-p4-jc8012p4a1.yaml
+++ b/builds/guition-esp32-p4-jc8012p4a1.yaml
@@ -21,7 +21,7 @@ external_components:
   - source:
       type: local
       path: ../components
-    components: [gsl3680, remote_image, espframe]
+    components: [gsl3680, remote_image, ledc, espframe]
 
 wifi:
   ap:

--- a/components/ledc/LICENSE
+++ b/components/ledc/LICENSE
@@ -1,0 +1,120 @@
+# ESPHome License
+
+Copyright (c) 2019 ESPHome
+
+The ESPHome License is made up of two base licenses: MIT and the GNU GENERAL PUBLIC LICENSE.
+The C++/runtime codebase of the ESPHome project (file extensions .c, .cpp, .h, .hpp, .tcc, .ino) are
+published under the GPLv3 license. The python codebase and all other parts of this codebase are
+published under the MIT license.
+
+Both MIT and GPLv3 licenses are attached to this document.
+
+## MIT License
+
+Copyright (c) 2019 ESPHome
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## GPLv3 License
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an

--- a/components/ledc/README.md
+++ b/components/ledc/README.md
@@ -1,0 +1,7 @@
+# Vendored ESPHome LEDC component
+
+This directory contains the LEDC output component from ESPHome 2026.8.2.
+
+Local change: ESP32-P4 uses the RCC-protected low-level LEDC reset available in
+ESP-IDF 5.5 instead of the deprecated, nonfunctional `periph_module_reset`
+compatibility API. Other targets retain the upstream implementation.

--- a/components/ledc/__init__.py
+++ b/components/ledc/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@OttoWinter"]

--- a/components/ledc/ledc_output.cpp
+++ b/components/ledc/ledc_output.cpp
@@ -1,0 +1,282 @@
+#include "ledc_output.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_ESP32
+
+#include <driver/gpio.h>
+#include <driver/ledc.h>
+#include <cinttypes>
+#include <esp_idf_version.h>
+#include <esp_private/periph_ctrl.h>
+#include <hal/ledc_ll.h>
+
+#define CLOCK_FREQUENCY 80e6f
+
+#ifdef SOC_LEDC_SUPPORT_APB_CLOCK
+#define DEFAULT_CLK LEDC_USE_APB_CLK
+#else
+#define DEFAULT_CLK LEDC_AUTO_CLK
+#endif
+
+static const uint8_t SETUP_ATTEMPT_COUNT_MAX = 5;
+
+namespace esphome::ledc {
+
+static const char *const TAG = "ledc.output";
+static bool ledc_peripheral_reset_done = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+static const int MAX_RES_BITS = LEDC_TIMER_BIT_MAX - 1;
+#if SOC_LEDC_SUPPORT_HS_MODE
+// Only ESP32 has LEDC_HIGH_SPEED_MODE
+inline ledc_mode_t get_speed_mode(uint8_t channel) { return channel < 8 ? LEDC_HIGH_SPEED_MODE : LEDC_LOW_SPEED_MODE; }
+#else
+// S2, C3, S3 only support LEDC_LOW_SPEED_MODE
+// See
+// https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/peripherals/ledc.html#functionality-overview
+inline ledc_mode_t get_speed_mode(uint8_t) { return LEDC_LOW_SPEED_MODE; }
+#endif
+
+#if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+// Classic ESP32 (currently the only target without SOC_LEDC_SUPPORT_FADE_STOP) can block in
+// ledc_ll_set_duty_start() while duty_start is set. We check the same conf1.duty_start bit here
+// to defer updates and avoid entering IDF's unbounded wait loop.
+//
+// This intentionally depends on the classic ESP32 LEDC register layout used by IDF's own LL HAL.
+// If another target without SOC_LEDC_SUPPORT_FADE_STOP is introduced, revisit this helper.
+static_assert(
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    true,
+#else
+    false,
+#endif
+    "LEDC duty_start pending check assumes classic ESP32 register layout; "
+    "re-evaluate for this target");
+
+static bool ledc_duty_update_pending(ledc_mode_t speed_mode, ledc_channel_t chan_num) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)
+  auto *hw = LEDC_LL_GET_HW(0);
+#else
+  auto *hw = LEDC_LL_GET_HW();
+#endif
+  return hw->channel_group[speed_mode].channel[chan_num].conf1.duty_start != 0;
+}
+#endif
+
+float ledc_max_frequency_for_bit_depth(uint8_t bit_depth) {
+  return static_cast<float>(CLOCK_FREQUENCY) / static_cast<float>(1 << bit_depth);
+}
+
+float ledc_min_frequency_for_bit_depth(uint8_t bit_depth, bool low_frequency) {
+  const float max_div_num = ((1 << MAX_RES_BITS) - 1) / (low_frequency ? 32.0f : 256.0f);
+  return static_cast<float>(CLOCK_FREQUENCY) / (max_div_num * static_cast<float>(1 << bit_depth));
+}
+
+optional<uint8_t> ledc_bit_depth_for_frequency(float frequency) {
+  ESP_LOGV(TAG, "Calculating resolution bit-depth for frequency %f", frequency);
+  for (int i = MAX_RES_BITS; i >= 1; i--) {
+    const float min_frequency = ledc_min_frequency_for_bit_depth(i, (frequency < 100));
+    const float max_frequency = ledc_max_frequency_for_bit_depth(i);
+    if (min_frequency <= frequency && frequency <= max_frequency) {
+      ESP_LOGV(TAG, "Resolution calculated as %d", i);
+      return i;
+    }
+  }
+  return {};
+}
+
+esp_err_t configure_timer_frequency(ledc_mode_t speed_mode, ledc_timer_t timer_num, ledc_channel_t chan_num,
+                                    uint8_t channel, uint8_t &bit_depth, float frequency) {
+  auto bit_depth_opt = ledc_bit_depth_for_frequency(frequency);
+  bit_depth = bit_depth_opt.value_or(0);
+  if (bit_depth < 1) {
+    ESP_LOGE(TAG, "Frequency %f can't be achieved with any bit depth", frequency);
+  }
+
+  ledc_timer_config_t timer_conf{};
+  timer_conf.speed_mode = speed_mode;
+  timer_conf.duty_resolution = static_cast<ledc_timer_bit_t>(bit_depth);
+  timer_conf.timer_num = timer_num;
+  timer_conf.freq_hz = (uint32_t) frequency;
+  timer_conf.clk_cfg = DEFAULT_CLK;
+
+  // Configure the time with fallback in case of error
+  int attempt_count_max = SETUP_ATTEMPT_COUNT_MAX;
+  esp_err_t init_result = ESP_FAIL;
+  while (attempt_count_max > 0 && init_result != ESP_OK) {
+    init_result = ledc_timer_config(&timer_conf);
+    if (init_result != ESP_OK) {
+      ESP_LOGW(TAG, "Unable to initialize timer with frequency %.1f and bit depth of %u", frequency, bit_depth);
+      if (bit_depth <= 1) {
+        break;
+      }
+      // try again with a lower bit depth
+      timer_conf.duty_resolution = static_cast<ledc_timer_bit_t>(--bit_depth);
+    }
+    attempt_count_max--;
+  }
+
+  return init_result;
+}
+
+constexpr int ledc_angle_to_htop(float angle, uint8_t bit_depth) {
+  return static_cast<int>(angle * ((1U << bit_depth) - 1) / 360.0f);
+}
+
+void LEDCOutput::write_state(float state) {
+  if (!this->initialized_) {
+    ESP_LOGW(TAG, "Not yet initialized");
+    return;
+  }
+
+  if (this->pin_->is_inverted())
+    state = 1.0f - state;
+
+  this->duty_ = state;
+  const uint32_t max_duty = (uint32_t(1) << this->bit_depth_) - 1;
+  const float duty_rounded = roundf(state * max_duty);
+  auto duty = static_cast<uint32_t>(duty_rounded);
+  if (duty == this->last_duty_) {
+    return;
+  }
+
+  ESP_LOGV(TAG, "Setting duty: %" PRIu32 " on channel %u", duty, this->channel_);
+  auto speed_mode = get_speed_mode(this->channel_);
+  auto chan_num = static_cast<ledc_channel_t>(this->channel_ % 8);
+  int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
+  if (duty == max_duty) {
+    ledc_stop(speed_mode, chan_num, 1);
+    this->last_duty_ = duty;
+  } else if (duty == 0) {
+    ledc_stop(speed_mode, chan_num, 0);
+    this->last_duty_ = duty;
+  } else {
+#if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+    if (ledc_duty_update_pending(speed_mode, chan_num)) {
+      ESP_LOGV(TAG, "Skipping LEDC duty update on channel %u while previous duty_start is still set", this->channel_);
+      return;
+    }
+#endif
+    ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
+    ledc_update_duty(speed_mode, chan_num);
+    this->last_duty_ = duty;
+  }
+}
+
+void LEDCOutput::setup() {
+  if (!ledc_peripheral_reset_done) {
+    ESP_LOGV(TAG, "Resetting LEDC peripheral to clear stale state after reboot");
+    // Skip under clang-tidy: the inlined HAL MMIO writes trip clang-analyzer-core.FixedAddressDereference
+#if !defined(CLANG_TIDY)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0)
+    PERIPH_RCC_ATOMIC() { ledc_ll_reset_register(0); }
+// ESP-IDF 5.5 deprecates the legacy reset API as nonfunctional on ESP32-P4.
+#elif defined(CONFIG_IDF_TARGET_ESP32P4) || ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    PERIPH_RCC_ATOMIC() {
+      ledc_ll_enable_reset_reg(true);
+      ledc_ll_enable_reset_reg(false);
+    }
+#else
+    periph_module_reset(PERIPH_LEDC_MODULE);
+#endif
+#endif
+    ledc_peripheral_reset_done = true;
+  }
+
+  auto speed_mode = get_speed_mode(this->channel_);
+  auto timer_num = static_cast<ledc_timer_t>((this->channel_ % 8) / 2);
+  auto chan_num = static_cast<ledc_channel_t>(this->channel_ % 8);
+
+  esp_err_t timer_init_result =
+      configure_timer_frequency(speed_mode, timer_num, chan_num, this->channel_, this->bit_depth_, this->frequency_);
+
+  if (timer_init_result != ESP_OK) {
+    ESP_LOGE(TAG, "Frequency %f can't be achieved with computed bit depth %u", this->frequency_, this->bit_depth_);
+    this->status_set_error();
+    return;
+  }
+  int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
+
+  ESP_LOGV(TAG, "Configured frequency %f with bit depth %u, angle %.1f° hpoint %u", this->frequency_, this->bit_depth_,
+           this->phase_angle_, hpoint);
+
+  ledc_channel_config_t chan_conf{};
+  chan_conf.gpio_num = static_cast<gpio_num_t>(this->pin_->get_pin());
+  chan_conf.speed_mode = speed_mode;
+  chan_conf.channel = chan_num;
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+  chan_conf.intr_type = LEDC_INTR_DISABLE;
+#endif
+  chan_conf.timer_sel = timer_num;
+  chan_conf.duty = this->inverted_ == this->pin_->is_inverted() ? 0 : (1U << this->bit_depth_);
+  chan_conf.hpoint = hpoint;
+  ledc_channel_config(&chan_conf);
+  this->initialized_ = true;
+  this->status_clear_error();
+}
+
+void LEDCOutput::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "Output:\n"
+                "  Channel: %u\n"
+                "  PWM Frequency: %.1f Hz\n"
+                "  Phase angle: %.1f°\n"
+                "  Bit depth: %u",
+                this->channel_, this->frequency_, this->phase_angle_, this->bit_depth_);
+  LOG_PIN("  Pin ", this->pin_);
+  ESP_LOGV(TAG,
+           "  Max frequency for bit depth: %f\n"
+           "  Min frequency for bit depth: %f\n"
+           "  Max frequency for bit depth-1: %f\n"
+           "  Min frequency for bit depth-1: %f\n"
+           "  Max frequency for bit depth+1: %f\n"
+           "  Min frequency for bit depth+1: %f\n"
+           "  Max res bits: %d\n"
+           "  Clock frequency: %f",
+           ledc_max_frequency_for_bit_depth(this->bit_depth_),
+           ledc_min_frequency_for_bit_depth(this->bit_depth_, (this->frequency_ < 100)),
+           ledc_max_frequency_for_bit_depth(this->bit_depth_ - 1),
+           ledc_min_frequency_for_bit_depth(this->bit_depth_ - 1, (this->frequency_ < 100)),
+           ledc_max_frequency_for_bit_depth(this->bit_depth_ + 1),
+           ledc_min_frequency_for_bit_depth(this->bit_depth_ + 1, (this->frequency_ < 100)), MAX_RES_BITS,
+           CLOCK_FREQUENCY);
+}
+
+void LEDCOutput::update_frequency(float frequency) {
+  auto bit_depth_opt = ledc_bit_depth_for_frequency(frequency);
+  if (!bit_depth_opt.has_value()) {
+    ESP_LOGE(TAG, "Frequency %f can't be achieved with any bit depth", this->frequency_);
+    this->status_set_error();
+  }
+  this->bit_depth_ = bit_depth_opt.value_or(8);
+  this->frequency_ = frequency;
+
+  if (!this->initialized_) {
+    ESP_LOGW(TAG, "Not yet initialized");
+    return;
+  }
+
+  auto speed_mode = get_speed_mode(this->channel_);
+  auto timer_num = static_cast<ledc_timer_t>((this->channel_ % 8) / 2);
+  auto chan_num = static_cast<ledc_channel_t>(this->channel_ % 8);
+
+  esp_err_t timer_init_result =
+      configure_timer_frequency(speed_mode, timer_num, chan_num, this->channel_, this->bit_depth_, this->frequency_);
+
+  if (timer_init_result != ESP_OK) {
+    ESP_LOGE(TAG, "Frequency %f can't be achieved with computed bit depth %u", this->frequency_, this->bit_depth_);
+    this->status_set_error();
+    return;
+  }
+
+  this->status_clear_error();
+
+  // re-apply duty
+  this->last_duty_ = UINT32_MAX;
+  this->write_state(this->duty_);
+}
+
+uint8_t next_ledc_channel = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+}  // namespace esphome::ledc
+
+#endif

--- a/components/ledc/ledc_output.h
+++ b/components/ledc/ledc_output.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/output/float_output.h"
+#include <cstdint>
+
+#ifdef USE_ESP32
+
+namespace esphome::ledc {
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern uint8_t next_ledc_channel;
+
+class LEDCOutput final : public output::FloatOutput, public Component {
+ public:
+  explicit LEDCOutput(InternalGPIOPin *pin) : pin_(pin) { this->channel_ = next_ledc_channel++; }
+
+  void set_channel(uint8_t channel) { this->channel_ = channel; }
+  void set_frequency(float frequency) { this->frequency_ = frequency; }
+  void set_phase_angle(float angle) { this->phase_angle_ = angle; }
+  /// Dynamically change frequency at runtime
+  void update_frequency(float frequency) override;
+
+  /// Setup LEDC.
+  void setup() override;
+  void dump_config() override;
+  /// HARDWARE setup priority
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  /// Override FloatOutput's write_state.
+  void write_state(float state) override;
+
+ protected:
+  InternalGPIOPin *pin_;
+  uint8_t channel_{};
+  uint8_t bit_depth_{};
+  float phase_angle_{0.0f};
+  float frequency_{};
+  float duty_{0.0f};
+  uint32_t last_duty_{UINT32_MAX};
+  bool initialized_ = false;
+};
+
+template<typename... Ts> class SetFrequencyAction final : public Action<Ts...> {
+ public:
+  SetFrequencyAction(LEDCOutput *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(float, frequency);
+
+  void play(const Ts &...x) {
+    float freq = this->frequency_.value(x...);
+    this->parent_->update_frequency(freq);
+  }
+
+ protected:
+  LEDCOutput *parent_;
+};
+
+}  // namespace esphome::ledc
+
+#endif

--- a/components/ledc/output.py
+++ b/components/ledc/output.py
@@ -1,0 +1,87 @@
+from esphome import automation, pins
+import esphome.codegen as cg
+from esphome.components import output
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CHANNEL,
+    CONF_FREQUENCY,
+    CONF_ID,
+    CONF_PHASE_ANGLE,
+    CONF_PIN,
+)
+
+DEPENDENCIES = ["esp32"]
+
+
+def calc_max_frequency(bit_depth):
+    return 80e6 / (2**bit_depth)
+
+
+def calc_min_frequency(bit_depth):
+    max_div_num = ((2**20) - 1) / 256.0
+    return 80e6 / (max_div_num * (2**bit_depth))
+
+
+def validate_frequency(value):
+    value = cv.frequency(value)
+    min_freq = calc_min_frequency(20)
+    max_freq = calc_max_frequency(1)
+    if value < min_freq:
+        raise cv.Invalid(
+            f"This frequency setting is not possible, please choose a higher frequency (at least {int(min_freq)}Hz)"
+        )
+    if value > max_freq:
+        raise cv.Invalid(
+            f"This frequency setting is not possible, please choose a lower frequency (at most {int(max_freq)}Hz)"
+        )
+    return value
+
+
+ledc_ns = cg.esphome_ns.namespace("ledc")
+LEDCOutput = ledc_ns.class_("LEDCOutput", output.FloatOutput, cg.Component)
+SetFrequencyAction = ledc_ns.class_("SetFrequencyAction", automation.Action)
+
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(LEDCOutput),
+        cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_FREQUENCY, default="1kHz"): cv.All(
+            cv.frequency, cv.float_range(min=0, min_included=False)
+        ),
+        cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=15),
+        cv.Optional(CONF_PHASE_ANGLE): cv.All(
+            cv.angle, cv.float_range(min=0.0, max=360.0)
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    gpio = await cg.gpio_pin_expression(config[CONF_PIN])
+    var = cg.new_Pvariable(config[CONF_ID], gpio)
+    await cg.register_component(var, config)
+    await output.register_output(var, config)
+    if CONF_CHANNEL in config:
+        cg.add(var.set_channel(config[CONF_CHANNEL]))
+    cg.add(var.set_frequency(config[CONF_FREQUENCY]))
+    if CONF_PHASE_ANGLE in config:
+        cg.add(var.set_phase_angle(config[CONF_PHASE_ANGLE]))
+
+
+@automation.register_action(
+    "output.ledc.set_frequency",
+    SetFrequencyAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(LEDCOutput),
+            cv.Required(CONF_FREQUENCY): cv.templatable(validate_frequency),
+        }
+    ),
+    synchronous=True,
+)
+async def ledc_set_frequency_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)
+    cg.add(var.set_frequency(template_))
+    return var

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -44,9 +44,6 @@ esphome:
     - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
     - "-DLV_USE_BIDI=1"
     - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
-    # ESPHome 2026.8 calls an ESP-IDF API that is deprecated and a no-op on
-    # ESP32-P4. Keep builds clean until ESPHome replaces that compatibility call.
-    - "-Wno-deprecated-declarations"
 
 # -----------------------------------------------------------------------------
 # ESP32-C6 coprocessor (WiFi and Bluetooth via SDIO)

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -40,12 +40,10 @@ esp32:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  platformio_options:
-    board_build.flash_mode: dio
-    build_flags:
-      - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
-      - "-DLV_USE_BIDI=1"
-      - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+  build_flags:
+    - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
+    - "-DLV_USE_BIDI=1"
+    - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
 
 # -----------------------------------------------------------------------------
 # ESP32-C6 coprocessor (WiFi and Bluetooth via SDIO)

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -158,7 +158,7 @@ external_components:
       url: ${espframe_component_url}
       ref: ${espframe_component_ref}
       path: components
-    components: [gsl3680, remote_image, espframe]
+    components: [gsl3680, remote_image, ledc, espframe]
     refresh: 0s
 
 espframe:

--- a/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1-v2/device/device.yaml
@@ -44,6 +44,9 @@ esphome:
     - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
     - "-DLV_USE_BIDI=1"
     - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+    # ESPHome 2026.8 calls an ESP-IDF API that is deprecated and a no-op on
+    # ESP32-P4. Keep builds clean until ESPHome replaces that compatibility call.
+    - "-Wno-deprecated-declarations"
 
 # -----------------------------------------------------------------------------
 # ESP32-C6 coprocessor (WiFi and Bluetooth via SDIO)

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -44,9 +44,6 @@ esphome:
     - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
     - "-DLV_USE_BIDI=1"
     - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
-    # ESPHome 2026.8 calls an ESP-IDF API that is deprecated and a no-op on
-    # ESP32-P4. Keep builds clean until ESPHome replaces that compatibility call.
-    - "-Wno-deprecated-declarations"
 
 # -----------------------------------------------------------------------------
 # ESP32-C6 coprocessor (WiFi and Bluetooth via SDIO)

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -40,12 +40,10 @@ esp32:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  platformio_options:
-    board_build.flash_mode: dio
-    build_flags:
-      - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
-      - "-DLV_USE_BIDI=1"
-      - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+  build_flags:
+    - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
+    - "-DLV_USE_BIDI=1"
+    - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
 
 # -----------------------------------------------------------------------------
 # ESP32-C6 coprocessor (WiFi and Bluetooth via SDIO)

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -158,7 +158,7 @@ external_components:
       url: ${espframe_component_url}
       ref: ${espframe_component_ref}
       path: components
-    components: [gsl3680, remote_image, espframe]
+    components: [gsl3680, remote_image, ledc, espframe]
     refresh: 0s
 
 espframe:

--- a/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -44,6 +44,9 @@ esphome:
     - "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y"
     - "-DLV_USE_BIDI=1"
     - "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+    # ESPHome 2026.8 calls an ESP-IDF API that is deprecated and a no-op on
+    # ESP32-P4. Keep builds clean until ESPHome replaces that compatibility call.
+    - "-Wno-deprecated-declarations"
 
 # -----------------------------------------------------------------------------
 # ESP32-C6 coprocessor (WiFi and Bluetooth via SDIO)

--- a/product/contract/devices.json
+++ b/product/contract/devices.json
@@ -18,6 +18,12 @@
       "CONFIG_HTTPD_MAX_URI_LEN": "128",
       "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
     },
+    "platformio_flash_mode": "dio",
+    "platformio_build_flags": [
+      "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
+      "-DLV_USE_BIDI=1",
+      "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+    ],
     "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",
@@ -246,6 +252,12 @@
       "CONFIG_HTTPD_MAX_URI_LEN": "128",
       "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
     },
+    "platformio_flash_mode": "dio",
+    "platformio_build_flags": [
+      "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
+      "-DLV_USE_BIDI=1",
+      "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+    ],
     "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",

--- a/product/contract/devices.json
+++ b/product/contract/devices.json
@@ -27,8 +27,7 @@
     "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",
-      "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
-      "-Wno-deprecated-declarations"
+      "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
     ],
     "esp32_hosted_variant": "esp32c6",
     "psram_mode": "hex",
@@ -261,8 +260,7 @@
     "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",
-      "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
-      "-Wno-deprecated-declarations"
+      "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
     ],
     "esp32_hosted_variant": "esp32c6",
     "psram_mode": "hex",

--- a/product/contract/devices.json
+++ b/product/contract/devices.json
@@ -18,8 +18,7 @@
       "CONFIG_HTTPD_MAX_URI_LEN": "128",
       "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
     },
-    "platformio_flash_mode": "dio",
-    "platformio_build_flags": [
+    "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",
       "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
@@ -246,8 +245,7 @@
       "CONFIG_HTTPD_MAX_URI_LEN": "128",
       "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
     },
-    "platformio_flash_mode": "dio",
-    "platformio_build_flags": [
+    "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",
       "-DLV_USE_ARABIC_PERSIAN_CHARS=1"

--- a/product/contract/devices.json
+++ b/product/contract/devices.json
@@ -21,7 +21,8 @@
     "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",
-      "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+      "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
+      "-Wno-deprecated-declarations"
     ],
     "esp32_hosted_variant": "esp32c6",
     "psram_mode": "hex",
@@ -248,7 +249,8 @@
     "build_flags": [
       "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
       "-DLV_USE_BIDI=1",
-      "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+      "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
+      "-Wno-deprecated-declarations"
     ],
     "esp32_hosted_variant": "esp32c6",
     "psram_mode": "hex",

--- a/product/contract/project.json
+++ b/product/contract/project.json
@@ -576,6 +576,7 @@
   "external_component_names": [
     "gsl3680",
     "remote_image",
+    "ledc",
     "espframe"
   ],
   "external_component_git_source_type": "git",

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1795,8 +1795,7 @@
         "CONFIG_HTTPD_MAX_URI_LEN": "128",
         "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
       },
-      "platformio_flash_mode": "dio",
-      "platformio_build_flags": [
+      "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",
         "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
@@ -2023,8 +2022,7 @@
         "CONFIG_HTTPD_MAX_URI_LEN": "128",
         "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
       },
-      "platformio_flash_mode": "dio",
-      "platformio_build_flags": [
+      "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",
         "-DLV_USE_ARABIC_PERSIAN_CHARS=1"

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1795,6 +1795,12 @@
         "CONFIG_HTTPD_MAX_URI_LEN": "128",
         "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
       },
+      "platformio_flash_mode": "dio",
+      "platformio_build_flags": [
+        "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
+        "-DLV_USE_BIDI=1",
+        "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+      ],
       "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",
@@ -2023,6 +2029,12 @@
         "CONFIG_HTTPD_MAX_URI_LEN": "128",
         "CONFIG_ESP_TASK_WDT_TIMEOUT_S": "30"
       },
+      "platformio_flash_mode": "dio",
+      "platformio_build_flags": [
+        "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
+        "-DLV_USE_BIDI=1",
+        "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+      ],
       "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1804,8 +1804,7 @@
       "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",
-        "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
-        "-Wno-deprecated-declarations"
+        "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
       ],
       "esp32_hosted_variant": "esp32c6",
       "psram_mode": "hex",
@@ -2038,8 +2037,7 @@
       "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",
-        "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
-        "-Wno-deprecated-declarations"
+        "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
       ],
       "esp32_hosted_variant": "esp32c6",
       "psram_mode": "hex",

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -1798,7 +1798,8 @@
       "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",
-        "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+        "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
+        "-Wno-deprecated-declarations"
       ],
       "esp32_hosted_variant": "esp32c6",
       "psram_mode": "hex",
@@ -2025,7 +2026,8 @@
       "build_flags": [
         "-DCONFIG_COMPILER_OPTIMIZATION_PERF=y",
         "-DLV_USE_BIDI=1",
-        "-DLV_USE_ARABIC_PERSIAN_CHARS=1"
+        "-DLV_USE_ARABIC_PERSIAN_CHARS=1",
+        "-Wno-deprecated-declarations"
       ],
       "esp32_hosted_variant": "esp32c6",
       "psram_mode": "hex",

--- a/product/espframe.json
+++ b/product/espframe.json
@@ -577,6 +577,7 @@
     "external_component_names": [
       "gsl3680",
       "remote_image",
+      "ledc",
       "espframe"
     ],
     "external_component_git_source_type": "git",

--- a/product/source-ownership.json
+++ b/product/source-ownership.json
@@ -59,6 +59,15 @@
   ],
   "vendored": [
     {
+      "path": "components/ledc",
+      "name": "ESPHome LEDC output component",
+      "upstream": "https://github.com/esphome/esphome/tree/2026.8.2/esphome/components/ledc",
+      "revision": "2026.8.2",
+      "license": "MIT",
+      "license_file": "components/ledc/LICENSE",
+      "local_changes": "Use the ESP-IDF RCC-protected low-level reset on ESP32-P4 instead of the deprecated, nonfunctional legacy peripheral reset API."
+    },
+    {
       "path": "components/gsl3680",
       "name": "GSL3680 ESPHome touchscreen component",
       "upstream": "https://github.com/kvj/esphome",

--- a/scripts/product_contract/devices.py
+++ b/scripts/product_contract/devices.py
@@ -25,7 +25,6 @@ def check_devices(product: dict, errors: list[str]) -> None:
             "esp32_variant",
             "flash_size",
             "framework_type",
-            "platformio_flash_mode",
             "esp32_hosted_variant",
             "psram_mode",
             "psram_speed",
@@ -69,11 +68,11 @@ def check_devices(product: dict, errors: list[str]) -> None:
                     errors.append(f"Device {slug} sdkconfig_options keys must be non-empty strings")
                 if not isinstance(value, str) or not value.strip():
                     errors.append(f"Device {slug} sdkconfig_options.{option} must be a non-empty string")
-        build_flags = device.get("platformio_build_flags", [])
+        build_flags = device.get("build_flags", [])
         if not isinstance(build_flags, list) or not build_flags:
-            errors.append(f"Device {slug} platformio_build_flags must be a non-empty list")
+            errors.append(f"Device {slug} build_flags must be a non-empty list")
         elif any(not isinstance(flag, str) or not flag.strip() for flag in build_flags):
-            errors.append(f"Device {slug} platformio_build_flags must only contain non-empty strings")
+            errors.append(f"Device {slug} build_flags must only contain non-empty strings")
         hardware_pins = device.get("hardware_pins", {})
         if not isinstance(hardware_pins, dict) or not hardware_pins:
             errors.append(f"Device {slug} hardware_pins must be a non-empty object")
@@ -182,7 +181,6 @@ def check_devices(product: dict, errors: list[str]) -> None:
             ("esp32_variant", f'variant: {device.get("esp32_variant", "")}'),
             ("flash_size", f'flash_size: {device.get("flash_size", "")}'),
             ("framework_type", f'type: {device.get("framework_type", "")}'),
-            ("platformio_flash_mode", f'board_build.flash_mode: {device.get("platformio_flash_mode", "")}'),
             ("esp32_hosted_variant", f'variant: {device.get("esp32_hosted_variant", "")}'),
             ("psram_mode", f'mode: {device.get("psram_mode", "")}'),
             ("psram_speed", f'speed: {device.get("psram_speed", "")}'),

--- a/scripts/product_contract/devices.py
+++ b/scripts/product_contract/devices.py
@@ -25,6 +25,7 @@ def check_devices(product: dict, errors: list[str]) -> None:
             "esp32_variant",
             "flash_size",
             "framework_type",
+            "platformio_flash_mode",
             "esp32_hosted_variant",
             "psram_mode",
             "psram_speed",
@@ -68,6 +69,11 @@ def check_devices(product: dict, errors: list[str]) -> None:
                     errors.append(f"Device {slug} sdkconfig_options keys must be non-empty strings")
                 if not isinstance(value, str) or not value.strip():
                     errors.append(f"Device {slug} sdkconfig_options.{option} must be a non-empty string")
+        legacy_build_flags = device.get("platformio_build_flags", [])
+        if not isinstance(legacy_build_flags, list) or not legacy_build_flags:
+            errors.append(f"Device {slug} platformio_build_flags must be a non-empty list")
+        elif any(not isinstance(flag, str) or not flag.strip() for flag in legacy_build_flags):
+            errors.append(f"Device {slug} platformio_build_flags must only contain non-empty strings")
         build_flags = device.get("build_flags", [])
         if not isinstance(build_flags, list) or not build_flags:
             errors.append(f"Device {slug} build_flags must be a non-empty list")

--- a/tests/product_contract_common_tests.py
+++ b/tests/product_contract_common_tests.py
@@ -64,6 +64,15 @@ def test_legacy_build_metadata_aliases_are_preserved() -> None:
         assert device["platformio_build_flags"] == device["build_flags"][:3]
 
 
+def test_p4_ledc_warning_fix_remains_narrowly_scoped() -> None:
+    source = (ROOT / "components" / "ledc" / "ledc_output.cpp").read_text(encoding="utf-8")
+
+    assert "defined(CONFIG_IDF_TARGET_ESP32P4) ||" in source
+    assert "periph_module_reset(PERIPH_LEDC_MODULE);" in source
+    for device in load_product()["devices"]:
+        assert "-Wno-deprecated-declarations" not in device["build_flags"]
+
+
 def test_contract_manifest_preserves_upgrade_boundaries() -> None:
     manifest = load_contract_manifest()
 

--- a/tests/product_contract_common_tests.py
+++ b/tests/product_contract_common_tests.py
@@ -56,6 +56,14 @@ def test_split_contract_matches_generated_legacy_manifest() -> None:
     assert load_product() == generated_legacy
 
 
+def test_legacy_build_metadata_aliases_are_preserved() -> None:
+    product = load_product()
+
+    for device in product["devices"]:
+        assert device["platformio_flash_mode"] == "dio"
+        assert device["platformio_build_flags"] == device["build_flags"][:3]
+
+
 def test_contract_manifest_preserves_upgrade_boundaries() -> None:
     manifest = load_contract_manifest()
 


### PR DESCRIPTION
## What changes when merged

- Move P4 device compiler flags from deprecated `esphome.platformio_options.build_flags` to `esphome.build_flags` while preserving the legacy product-metadata aliases.
- Remove the ignored `board_build.flash_mode` setting from device configuration while retaining its compatibility metadata.
- Vendor ESPHome 2026.8.2's LEDC component with one targeted ESP32-P4 compatibility change: use the IDF RCC/LL reset path already used by ESP-IDF 6 instead of the deprecated, nonfunctional `periph_module_reset` call on IDF 5.5.
- Keep the upstream LEDC reset behavior unchanged for other ESP32 targets and add regression coverage preventing a global deprecation-warning suppression.

## Automated checks

- [x] `npm run check:pr` passed
- [x] ESPHome 2026.8.2 factory compile: `guition-esp32-p4-jc8012p4a1`
- [x] ESPHome 2026.8.2 factory compile: `guition-esp32-p4-jc8012p4a1-v2`
- [x] Both LEDC translation units compiled without the reported warning
- [x] CI checks passed

## Device testing

- [ ] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [x] Needs device testing before merge

PR Validation workflow run/artifact: Validate PR Gate passed; firmware compilation was validated locally because the workflow's firmware job was skipped.

Firmware artifact (`firmware-test-<device>`): Local factory binaries only; no uploaded PR artifact.

Device tested: None

Result/notes: Both factory firmware builds completed successfully. The deprecated ESPHome configuration warnings and the reported ESP32-P4 LEDC compiler warning are gone. Physical backlight initialization has not been tested.

## Notes for reviewers

- `product/espframe.json` was regenerated from the product contract and retains `platformio_build_flags` and `platformio_flash_mode` for contract-v2 consumers.
- `components/ledc` is based on ESPHome 2026.8.2 under MIT; its README and source-ownership entry document the single local conditional change.
- The prior global `-Wno-deprecated-declarations` suppression has been removed.
