### PR TITLE
Add 50px black rounded corners to slideshow photos

### DIFF
--- a/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/screen_slideshow.yaml
@@ -100,6 +100,24 @@ lvgl:
                   pad_all: 0
                   scrollable: false
                   clickable: false
+        # Expand a transparent border beyond the screen so only its rounded
+        # inner corners cover the photos. Inner radius = 100 - 50 = 50px.
+        # Percentage sizing follows screen rotation; touches pass through.
+        - obj:
+            id: slideshow_corner_overlay
+            align: CENTER
+            width: 100%
+            height: 100%
+            transform_width: 50
+            transform_height: 50
+            radius: 100
+            bg_opa: 0%
+            border_color: 0x000000
+            border_opa: 100%
+            border_width: 50
+            pad_all: 0
+            scrollable: false
+            clickable: false
         - obj:
             id: clock_container
             align: BOTTOM_LEFT


### PR DESCRIPTION
## What changes when merged

- Slideshow photos have black rounded masks in all four screen corners, with a 50px inner radius. The overlay covers single images and portrait pairs, follows screen rotation, and lets touches through.
- Uses one transparent LVGL object with its border expanded beyond the display, leaving only the rounded inner corners visible.

## Automated checks

- [x] `npm run check:pr` passed
- [x] CI `Validate PR Gate` passed (56s).
- `git diff --check` passed.
- Full ESPHome 2026.8.2 development firmware compile passed.
- The first browser-test attempt hit sandbox socket restrictions; the complete check passed when rerun outside the sandbox.

## Device testing

- [ ] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [x] Needs device testing before merge

PR Validation workflow run/artifact: Not used; testing a local ESPHome 2026.8.2 `dev.yaml` build.

Firmware artifact (`firmware-test-<device>`): Local development firmware.

Device tested: Guition ESP32-P4 JC8012P4A1 at `192.168.6.106`.

Result/notes: Local development firmware compiled and uploaded successfully over OTA. After reboot, the display responded to both ping packets and its web UI returned HTTP 200. Visual assessment of corner size, photo changes, rotations, and touch gestures remains for the user on the physical display.

## Notes for reviewers

- Initial 50px presentation trial requested by the user. No new setting or saved-preference change.
