### PR TITLE
Fix release RAM overflow and local budget checks

### DIFF
--- a/components/espframe/slideshow_component.h
+++ b/components/espframe/slideshow_component.h
@@ -38,9 +38,12 @@ enum SlideshowCommandKind : uint8_t {
 
 struct SlideshowCommand {
   SlideshowCommandKind kind = SLIDESHOW_COMMAND_NONE;
-  int slot = -1;
+  // Ring-buffer slots are -1 (none), 0, 1 or 2.
+  int8_t slot = -1;
   uint32_t delay_ms = 0;
 };
+
+static_assert(sizeof(SlideshowCommand) == 8, "Keep the command queue compact");
 
 class SlideshowCommandQueue {
  public:

--- a/components/espframe/slideshow_controller.h
+++ b/components/espframe/slideshow_controller.h
@@ -40,10 +40,13 @@ struct PortraitPairState {
 
 struct FetchJob {
   FetchJobKind kind = FETCH_JOB_SLOT;
-  int slot = -1;
+  // Ring-buffer slots are -1 (none), 0, 1 or 2.
+  int8_t slot = -1;
   uint8_t priority = 0;
   uint32_t queued_ms = 0;
 };
+
+static_assert(sizeof(FetchJob) == 8, "Keep the fetch queue compact");
 
 class FetchQueue {
  public:

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from product_config import github_workflow_metadata, release_matrix_devices
@@ -15,10 +16,21 @@ ROOT = Path(__file__).resolve().parent.parent
 TEST_FIRMWARE_VERSION = "v0.0.0"
 
 
-def run(command: list[str], label: str) -> bool:
-    print(f"[RUN] {label}")
-    result = subprocess.run(command)
-    if result.returncode != 0:
+def run(command: list[str], label: str, log_path: Path | None = None) -> bool:
+    print(f"[RUN] {label}", flush=True)
+    if log_path is None:
+        returncode = subprocess.run(command).returncode
+    else:
+        # ESPHome writes its size report to stderr. Stream and retain both
+        # streams so the same RAM/flash checks as CI see the complete report.
+        with log_path.open("w") as log, subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        ) as process:
+            for line in process.stdout:
+                print(line, end="", flush=True)
+                log.write(line)
+            returncode = process.wait()
+    if returncode != 0:
         print(f"[FAIL] {label}")
         return False
     print(f"[PASS] {label}")
@@ -90,49 +102,31 @@ def compile_firmware() -> bool:
         # subdirectory; PlatformIO's former .pioenvs directory is no longer
         # created.
         build_dir = ROOT / cache_dir / "build" / build_name / "build"
-        factory_command = esphome_compile_command(
-            image,
-            version,
-            mount,
-            remove_flag,
-            f"{mount}/builds/{device['yaml']}.factory.yaml",
-        )
-        checks.append(run(factory_command, f"ESPHome factory compile ({device['slug']})"))
-        checks.append(
-            run(
-                [
-                    sys.executable,
-                    str(ROOT / "scripts" / "check_build_budgets.py"),
-                    "--profile",
-                    "factory",
-                    "--binary",
-                    str(build_dir / "firmware.factory.bin"),
-                ],
-                f"Firmware factory budget ({device['slug']})",
+        for profile, suffix, compile_label in (
+            ("factory", ".factory.yaml", "ESPHome factory compile"),
+            ("ota", ".yaml", "ESPHome OTA compile"),
+        ):
+            profile_label = "OTA" if profile == "ota" else "factory"
+            command = esphome_compile_command(
+                image, version, mount, remove_flag,
+                f"{mount}/builds/{device['yaml']}{suffix}",
             )
-        )
-
-        ota_command = esphome_compile_command(
-            image,
-            version,
-            mount,
-            remove_flag,
-            f"{mount}/builds/{device['yaml']}.yaml",
-        )
-        checks.append(run(ota_command, f"ESPHome OTA compile ({device['slug']})"))
-        checks.append(
-            run(
-                [
-                    sys.executable,
-                    str(ROOT / "scripts" / "check_build_budgets.py"),
-                    "--profile",
-                    "ota",
-                    "--binary",
-                    str(build_dir / "firmware.ota.bin"),
-                ],
-                f"Firmware OTA budget ({device['slug']})",
-            )
-        )
+            with tempfile.TemporaryDirectory(prefix="espframe-compile-") as log_dir:
+                log_path = Path(log_dir) / f"{device['slug']}.{profile}.log"
+                compiled = run(command, f"{compile_label} ({device['slug']})", log_path)
+                checks.append(compiled)
+                if not compiled:
+                    continue
+                checks.append(run(
+                    [
+                        sys.executable,
+                        str(ROOT / "scripts" / "check_build_budgets.py"),
+                        "--compile-log", str(log_path),
+                        "--profile", profile,
+                        "--binary", str(build_dir / f"firmware.{profile}.bin"),
+                    ],
+                    f"Firmware {profile_label} budget ({device['slug']})",
+                ))
     return all(checks)
 
 

--- a/tests/espframe_helper_tests.cpp
+++ b/tests/espframe_helper_tests.cpp
@@ -807,6 +807,38 @@ static void test_slideshow_slot_actions() {
   assert(!flags.fetch_in_flight[0]);
 }
 
+static void test_compact_queue_slots_and_wraparound() {
+  SlideshowCommandQueue commands;
+  for (int round = 0; round < 3; ++round) {
+    for (size_t i = 0; i < SlideshowCommandQueue::CAPACITY; ++i) {
+      assert(commands.push(SLIDESHOW_COMMAND_FETCH_INTO_SLOT, int(i % 4) - 1, UINT32_MAX));
+    }
+    assert(!commands.push(SLIDESHOW_COMMAND_FETCH_INTO_SLOT, 0));
+    for (size_t i = 0; i < SlideshowCommandQueue::CAPACITY; ++i) {
+      SlideshowCommand command;
+      assert(commands.pop(command));
+      assert(command.slot == int(i % 4) - 1);
+      assert(command.delay_ms == UINT32_MAX);
+      assert(command.kind == SLIDESHOW_COMMAND_FETCH_INTO_SLOT);
+      // Keep the queue full while moving the head through its ring storage.
+      if (i == 0) assert(commands.push(SLIDESHOW_COMMAND_LOG_DIAG));
+    }
+    SlideshowCommand command;
+    assert(commands.pop(command) && command.slot == -1);
+    assert(commands.empty());
+  }
+  FetchQueue fetches;
+  for (int slot = -1; slot <= 2; ++slot)
+    assert(fetches.enqueue(FETCH_JOB_SLOT, slot, uint8_t(slot + 1), UINT32_MAX));
+  for (int slot = 2; slot >= -1; --slot) {
+    FetchJob job;
+    assert(fetches.pop(job));
+    assert(job.slot == slot && job.priority == slot + 1);
+    assert(job.queued_ms == UINT32_MAX);
+  }
+  assert(fetches.empty());
+}
+
 static void test_fetch_queue_and_error_handling() {
   SlotMeta slot0 = make_slot("active", false);
   SlotMeta slot1 = make_slot("next", false);
@@ -1658,6 +1690,7 @@ int main() {
   test_smart_filter_helpers();
   test_immich_request_state();
   test_slideshow_slot_actions();
+  test_compact_queue_slots_and_wraparound();
   test_fetch_queue_and_error_handling();
   test_slideshow_component_commands();
   test_slideshow_component_prefetch_and_deferred_updates();

--- a/tests/release_ready_tests.py
+++ b/tests/release_ready_tests.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import contextlib
 import io
 import sys
+import subprocess
+import tempfile
+from unittest.mock import patch
 from pathlib import Path
 
 
@@ -32,7 +35,13 @@ def test_compile_firmware_runs_versioned_factory_and_ota_commands() -> None:
     original_devices = check_release_ready.release_matrix_devices
     original_run = check_release_ready.run
 
-    def fake_run(command: list[str], label: str) -> bool:
+    def fake_run(command: list[str], label: str, log_path: Path | None = None) -> bool:
+        if "compile" in command:
+            assert log_path is not None
+            log_path.write_text("RAM: used 137060 bytes from 571392 bytes\n")
+        else:
+            assert "--compile-log" in command
+            assert "137060" in Path(command[command.index("--compile-log") + 1]).read_text()
         captured.append((label, command))
         return True
 
@@ -91,6 +100,53 @@ def test_compile_firmware_rejects_missing_metadata() -> None:
     finally:
         check_release_ready.github_workflow_metadata = original_metadata
         check_release_ready.run = original_run
+
+
+def test_run_captures_stderr_and_preserves_failure() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        log = Path(directory) / "compile.log"
+        with contextlib.redirect_stdout(io.StringIO()):
+            assert not check_release_ready.run(
+                [sys.executable, "-c", "import sys; print('size report', file=sys.stderr); sys.exit(7)"],
+                "failed compile", log,
+            )
+        assert "size report" in log.read_text()
+
+
+def test_compile_firmware_rejects_ram_over_budget() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        binary = Path(directory) / "firmware.bin"
+        binary.write_bytes(b"test")
+
+        def fake_compile(command, label, log_path=None):
+            if log_path is not None:
+                log_path.write_text(
+                    "RAM: [==        ] 23.9% (used 137060 bytes from 573440 bytes)\n"
+                    "Flash: [===       ] 30.0% (used 2500000 bytes from 8388608 bytes)\n"
+                )
+                return True
+            command = list(command)
+            command[command.index("--binary") + 1] = str(binary)
+            result = subprocess.run(command, capture_output=True, text=True)
+            assert "ram_used_bytes is 137060, over budget 137000" in result.stderr
+            assert result.returncode == 1
+            return result.returncode == 0
+
+        with patch.object(check_release_ready, "run", fake_compile):
+            assert not check_release_ready.compile_firmware()
+
+
+def test_failed_compile_skips_budget_checks_for_stale_binaries() -> None:
+    commands = []
+
+    def fail_compile(command, label, log_path=None):
+        commands.append(command)
+        assert log_path is not None
+        return False
+
+    with patch.object(check_release_ready, "run", fail_compile):
+        assert not check_release_ready.compile_firmware()
+    assert len(commands) == 2 * len(check_release_ready.release_matrix_devices())
 
 
 def main() -> int:


### PR DESCRIPTION
## What changes when merged

- Fix the v1.14.0 OTA build's 137,060-byte RAM usage exceeding the unchanged 137,000-byte limit. Store slideshow queue slot indices in signed bytes, saving 96 bytes across the existing queues without changing capacities, delays, priorities, or valid slot values.
- Make local release readiness capture ESPHome output and enforce RAM and flash budgets as well as binary sizes, matching CI. Failed compiles skip checks against stale binaries.

## Automated checks

- [x] `npm run check:pr` passed
- [x] CI passed: [Validate PR Gate](https://github.com/jtenniswood/espframe/actions/runs/34694181143)
- Regression coverage checks queue capacity, wraparound, signed sentinel slots, priority ordering, compile stderr capture, compile failures, and rejection of the exact 137,060-byte RAM report.
- Full ESPHome 2026.8.2 Docker factory and OTA builds passed for both models, using the updated `compile_firmware()` gate. Factory RAM: 136,900 bytes; OTA RAM: 136,964 bytes on each model. All RAM, flash, and binary-size checks passed.

## Device testing

- [x] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [ ] Needs device testing before merge

PR Validation workflow run/artifact: all four local Docker builds passed; no manual workflow dispatched.

Firmware artifact (`firmware-test-<device>`): not generated by a manual workflow.

Device tested: none.

Result/notes: queue storage layout only; host tests cover unchanged behavior. No device was flashed.

## Notes for reviewers

- Firmware budgets, saved settings, entity names, and public configuration remain unchanged. OTA static RAM has 36 bytes of headroom under the existing budget; future additions must continue to pass the gate.
- The failed v1.14.0 release remains published without firmware assets. This PR must be merged and a new release authorized before fixed release assets can be published; the existing tag is unchanged.
