### PR TITLE
Reduce slideshow automation RAM by 1.3 KiB

### DIFF
--- a/common/addon/immich_api.yaml
+++ b/common/addon/immich_api.yaml
@@ -692,79 +692,39 @@ script:
   - id: immich_fetch_into_slot
     mode: single
     then:
-      - if:
-          condition:
-            not:
-              wifi.connected:
-          then:
-            - logger.log:
-                level: DEBUG
-                tag: immich
-                format: "Fetch paused (wifi disconnected)"
-            - script.stop: immich_fetch_into_slot
-      - if:
-          condition:
-            lambda: 'return id(immich_url).state.empty() || id(immich_api_key_text).state.empty();'
-          then:
-            - logger.log:
-                level: WARN
-                tag: immich
-                format: "Immich URL or API key not configured"
-            - script.stop: immich_fetch_into_slot
-      - if:
-          condition:
-            lambda: 'return id(backlight_paused);'
-          then:
-            - logger.log:
-                level: INFO
-                tag: immich
-                format: "Fetch paused (backlight off)"
-            - script.stop: immich_fetch_into_slot
-      - if:
-          condition:
-            lambda: 'return id(immich_request_state).cooldown_active(millis());'
-          then:
-            - logger.log:
-                level: DEBUG
-                tag: immich
-                format: "Fetch paused (connection retry cooldown)"
-            - script.stop: immich_fetch_into_slot
-      - if:
-          condition:
-            lambda: 'return id(espframe_core).slideshow().state().target_slot != id(espframe_core).slideshow().state().active_slot && id(espframe_core).slideshow().state().portrait.workflow_busy;'
-          then:
-            - script.execute: delayed_prefetch_chain
-            - script.stop: immich_fetch_into_slot
-      - if:
-          condition:
-            lambda: 'return any_slot_fetch_in_flight(id(espframe_core).slideshow().state().slot_flags) && !id(espframe_core).slideshow().state().slot_flags.fetch_in_flight[id(espframe_core).slideshow().state().target_slot];'
-          then:
-            - script.execute: delayed_prefetch_chain
-            - script.stop: immich_fetch_into_slot
-      - if:
-          condition:
-            lambda: 'return id(espframe_core).slideshow().state().slot_flags.fetch_in_flight[id(espframe_core).slideshow().state().target_slot];'
-          then:
-            - lambda: |-
-                ESP_LOGD("immich", "Slot %d fetch already in flight, skipping API fetch", id(espframe_core).slideshow().state().target_slot);
-            - script.stop: immich_fetch_into_slot
-      - if:
-          condition:
-            lambda: |-
-              return id(immich_img_0).is_downloading() ||
-                     id(immich_img_1).is_downloading() ||
-                     id(immich_img_2).is_downloading() ||
-                     id(immich_portrait_left).is_downloading() ||
-                     id(immich_portrait_right).is_downloading() ||
-                     id(immich_portrait_preload_left).is_downloading() ||
-                     id(immich_portrait_preload_right).is_downloading();
-          then:
-            - logger.log:
-                level: DEBUG
-                tag: immich
-                format: "Fetch deferred (image download active)"
-            - script.execute: delayed_prefetch_chain
-            - script.stop: immich_fetch_into_slot
+      - lambda: |-
+          using esphome::espframe::SlotFetchDecision;
+          const auto decision = id(espframe_core).check_slot_fetch(
+            esphome::wifi::global_wifi_component->is_connected(),
+            !id(immich_url).state.empty() && !id(immich_api_key_text).state.empty(),
+            id(backlight_paused), id(immich_request_state).cooldown_active(millis()),
+            id(immich_img_0).is_downloading() || id(immich_img_1).is_downloading() ||
+            id(immich_img_2).is_downloading() || id(immich_portrait_left).is_downloading() ||
+            id(immich_portrait_right).is_downloading() || id(immich_portrait_preload_left).is_downloading() ||
+            id(immich_portrait_preload_right).is_downloading());
+          if (decision == SlotFetchDecision::ALLOW) return;
+          switch (decision) {
+            case SlotFetchDecision::WIFI_DISCONNECTED:
+              ESP_LOGD("immich", "Fetch paused (wifi disconnected)"); break;
+            case SlotFetchDecision::MISSING_CONFIG:
+              ESP_LOGW("immich", "Immich URL or API key not configured"); break;
+            case SlotFetchDecision::PAUSED:
+              ESP_LOGI("immich", "Fetch paused (backlight off)"); break;
+            case SlotFetchDecision::COOLDOWN:
+              ESP_LOGD("immich", "Fetch paused (connection retry cooldown)"); break;
+            case SlotFetchDecision::SLOT_BUSY:
+              ESP_LOGD("immich", "Slot %d fetch already in flight, skipping API fetch",
+                       id(espframe_core).slideshow().state().target_slot); break;
+            case SlotFetchDecision::IMAGE_BUSY:
+              ESP_LOGD("immich", "Fetch deferred (image download active)"); break;
+            case SlotFetchDecision::INVALID_SLOT:
+              ESP_LOGW("immich", "Fetch paused (invalid target slot)"); break;
+            default: break;
+          }
+          if (esphome::espframe::slot_fetch_needs_defer(decision)) id(delayed_prefetch_chain).execute();
+          // Stopping this script suppresses all subsequent actions, including
+          // marking a slot busy. Returning from a lambda alone would not.
+          id(immich_fetch_into_slot).stop();
       - lambda: 'mark_slot_fetch_in_flight(id(espframe_core).slideshow().state().target_slot, id(espframe_core).slideshow().state().slot_flags, millis());'
       - script.execute: sync_immich_filter_config
       - delay: 1ms

--- a/common/addon/immich_slideshow.yaml
+++ b/common/addon/immich_slideshow.yaml
@@ -717,29 +717,30 @@ script:
     then:
       # Stop every API worker before clearing target_slot and request flags. Their
       # late callbacks read shared slideshow state and must not outlive recovery.
-      - script.stop: immich_fetch_memory_into_slot
-      - script.stop: immich_fetch_memory_window_day
-      - script.stop: immich_fetch_memory_asset
-      - script.stop: immich_fetch_metadata_into_slot
-      - script.stop: immich_fetch_album_count
-      - script.stop: immich_fetch_statistics_count
-      - script.stop: immich_fetch_metadata_page_probe
-      - script.stop: immich_fetch_metadata_page
-      - script.stop: immich_fetch_into_slot
-      - script.stop: immich_fetch_portrait_companion
-      - script.stop: delayed_prefetch_chain
-      - script.stop: deferred_companion_search
-      - script.stop: deferred_fetch_into_slot
-      - script.stop: deferred_rejected_slot_fetch
-      - script.stop: deferred_slot0_image_update
-      - script.stop: deferred_slot1_image_update
-      - script.stop: deferred_slot2_image_update
-      - script.stop: deferred_portrait_left_update
-      - script.stop: deferred_portrait_right_update
-      - script.stop: deferred_preload_left_update
-      - script.stop: deferred_preload_right_update
-      - script.stop: immich_fetch_retry
       - lambda: |-
+          id(espframe_core).stop_slideshow_workers(
+            id(immich_fetch_memory_into_slot),
+            id(immich_fetch_memory_window_day),
+            id(immich_fetch_memory_asset),
+            id(immich_fetch_metadata_into_slot),
+            id(immich_fetch_album_count),
+            id(immich_fetch_statistics_count),
+            id(immich_fetch_metadata_page_probe),
+            id(immich_fetch_metadata_page),
+            id(immich_fetch_into_slot),
+            id(immich_fetch_portrait_companion),
+            id(delayed_prefetch_chain),
+            id(deferred_companion_search),
+            id(deferred_fetch_into_slot),
+            id(deferred_rejected_slot_fetch),
+            id(deferred_slot0_image_update),
+            id(deferred_slot1_image_update),
+            id(deferred_slot2_image_update),
+            id(deferred_portrait_left_update),
+            id(deferred_portrait_right_update),
+            id(deferred_preload_left_update),
+            id(deferred_preload_right_update),
+            id(immich_fetch_retry));
           auto &state = id(espframe_core).slideshow().state();
           state.diagnostic_reason = "pipeline watchdog timeout";
           state.last_diagnostic_ms = 0;

--- a/common/addon/screen_rotation.yaml
+++ b/common/addon/screen_rotation.yaml
@@ -48,35 +48,18 @@ script:
             - select.set:
                 id: screen_rotation_select
                 option: "0"
+      # One restartable delay replaces the four identical delayed continuations.
+      # The validation/select action above retains its existing reentrant behavior.
       - if:
           condition:
-            lambda: 'return id(screen_rotation_select).current_option() == "0";'
+            lambda: |-
+              const auto option = id(screen_rotation_select).current_option();
+              return option == "0" || option == "90" || option == "180" || option == "270";
           then:
-            - lvgl.display.set_rotation: ${screen_rotation_0}
-            - switch.turn_on: portrait_pairing_enabled
-            - delay: 100ms
-            - script.execute: immich_reapply_current_image_layout
-      - if:
-          condition:
-            lambda: 'return id(screen_rotation_select).current_option() == "90";'
-          then:
-            - lvgl.display.set_rotation: ${screen_rotation_90}
-            - switch.turn_off: portrait_pairing_enabled
-            - delay: 100ms
-            - script.execute: immich_reapply_current_image_layout
-      - if:
-          condition:
-            lambda: 'return id(screen_rotation_select).current_option() == "180";'
-          then:
-            - lvgl.display.set_rotation: ${screen_rotation_180}
-            - switch.turn_on: portrait_pairing_enabled
-            - delay: 100ms
-            - script.execute: immich_reapply_current_image_layout
-      - if:
-          condition:
-            lambda: 'return id(screen_rotation_select).current_option() == "270";'
-          then:
-            - lvgl.display.set_rotation: ${screen_rotation_270}
-            - switch.turn_off: portrait_pairing_enabled
+            - lambda: |-
+                id(espframe_core).apply_screen_rotation(
+                  id(screen_rotation_select).current_option(),
+                  {${screen_rotation_0}, ${screen_rotation_90}, ${screen_rotation_180}, ${screen_rotation_270}},
+                  id(frame_lvgl), id(portrait_pairing_enabled));
             - delay: 100ms
             - script.execute: immich_reapply_current_image_layout

--- a/components/espframe/automation_controller.h
+++ b/components/espframe/automation_controller.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+namespace esphome::espframe {
+
+// Immediate calls only: no callbacks, allocation, or persistent pointer registry.
+template<typename... Scripts> void stop_scripts_in_order(Scripts *...scripts) {
+  (scripts->stop(), ...);
+}
+
+struct RotationPlan {
+  int degrees;
+  bool portrait_pairing;
+  bool valid;
+};
+inline RotationPlan rotation_plan(const std::string &option, const std::array<int, 4> &panel_rotations) {
+  if (option == "0") return {panel_rotations[0], true, true};
+  if (option == "90") return {panel_rotations[1], false, true};
+  if (option == "180") return {panel_rotations[2], true, true};
+  if (option == "270") return {panel_rotations[3], false, true};
+  return {0, false, false};
+}
+template<typename Display, typename PairingSwitch>
+void apply_rotation_plan(const RotationPlan &plan, Display *display, PairingSwitch *pairing) {
+  if (!plan.valid) return;
+  display->set_rotation(plan.degrees);
+  if (plan.portrait_pairing) pairing->turn_on();
+  else pairing->turn_off();
+}
+
+enum class SlotFetchDecision : uint8_t {
+  ALLOW, WIFI_DISCONNECTED, MISSING_CONFIG, PAUSED, COOLDOWN,
+  PORTRAIT_BUSY, ANOTHER_FETCH_BUSY, SLOT_BUSY, IMAGE_BUSY, INVALID_SLOT,
+};
+
+// Preserve the YAML guard precedence. Evaluate slot flags only after the early
+// gates, so a paused/disconnected request never depends on a usable target.
+template<typename State>
+SlotFetchDecision slot_fetch_decision(const State &state, bool wifi_connected, bool configured,
+                                     bool paused, bool cooldown, bool image_downloading) {
+  if (!wifi_connected) return SlotFetchDecision::WIFI_DISCONNECTED;
+  if (!configured) return SlotFetchDecision::MISSING_CONFIG;
+  if (paused) return SlotFetchDecision::PAUSED;
+  if (cooldown) return SlotFetchDecision::COOLDOWN;
+  if (state.target_slot != state.active_slot && state.portrait.workflow_busy)
+    return SlotFetchDecision::PORTRAIT_BUSY;
+  if (state.target_slot < 0 || state.target_slot > 2) return SlotFetchDecision::INVALID_SLOT;
+  bool any_fetch = false;
+  for (bool busy : state.slot_flags.fetch_in_flight) any_fetch |= busy;
+  const bool slot_busy = state.slot_flags.fetch_in_flight[state.target_slot];
+  if (any_fetch && !slot_busy) return SlotFetchDecision::ANOTHER_FETCH_BUSY;
+  if (slot_busy) return SlotFetchDecision::SLOT_BUSY;
+  if (image_downloading) return SlotFetchDecision::IMAGE_BUSY;
+  return SlotFetchDecision::ALLOW;
+}
+inline bool slot_fetch_needs_defer(SlotFetchDecision decision) {
+  return decision == SlotFetchDecision::PORTRAIT_BUSY || decision == SlotFetchDecision::ANOTHER_FETCH_BUSY ||
+         decision == SlotFetchDecision::IMAGE_BUSY;
+}
+
+}  // namespace esphome::espframe

--- a/components/espframe/espframe_component.h
+++ b/components/espframe/espframe_component.h
@@ -6,6 +6,7 @@
 #include "frame_identity_api.h"
 #include "espframe_helpers.h"
 #include "memory_pressure.h"
+#include "automation_controller.h"
 
 namespace esphome {
 namespace espframe {
@@ -53,6 +54,22 @@ class EspFrameComponent : public Component, public ConfigurationUpdateScheduler 
   float get_setup_priority() const override { return 1000.0f; }
 
   void schedule_configuration_update(std::function<void()> &&update) override { this->defer(std::move(update)); }
+
+  template<typename... Scripts> void stop_slideshow_workers(Scripts *...scripts) {
+    stop_scripts_in_order(scripts...);
+  }
+
+  template<typename Display, typename PairingSwitch>
+  void apply_screen_rotation(const std::string &option, const std::array<int, 4> &rotations,
+                             Display *display, PairingSwitch *pairing) {
+    apply_rotation_plan(rotation_plan(option, rotations), display, pairing);
+  }
+
+  SlotFetchDecision check_slot_fetch(bool wifi_connected, bool configured, bool paused,
+                                    bool cooldown, bool image_downloading) const {
+    return slot_fetch_decision(this->slideshow_.state(), wifi_connected, configured, paused, cooldown,
+                               image_downloading);
+  }
 
   EspFrameSlideshow &slideshow() { return this->slideshow_; }
   const EspFrameSlideshow &slideshow() const { return this->slideshow_; }

--- a/devices/guition-esp32-p4-jc8012p4a1/device/lvgl_base.yaml
+++ b/devices/guition-esp32-p4-jc8012p4a1/device/lvgl_base.yaml
@@ -6,6 +6,7 @@
 # =============================================================================
 
 lvgl:
+  id: frame_lvgl
   buffer_size: 6%
   byte_order: little_endian
   rotation: ${screen_rotation_0}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -88,6 +88,28 @@ The helper tests include the production slideshow model; only platform logging a
 
 This group compiles and runs host-side C++ tests for firmware helper logic, then checks timezone data. It is much faster than a full ESPHome compile and is the right place to cover slideshow decisions, Immich request building, date handling, duration parsing, and other logic that can be tested without a device.
 
+### Automation controller checks
+
+`npm run test:automation-controller` covers ordered worker cancellation, panel
+rotation mappings and all 4,608 combinations of the slot-fetch gates. It runs as
+part of `npm run check:pr`.
+
+For changes to script cancellation or rotation sequencing, also run the pinned
+ESPHome host integration test:
+
+```sh
+docker run --rm -v "${PWD}:/config" --entrypoint python \
+  ghcr.io/esphome/esphome:2026.8.2 /config/tests/automation_runtime_tests.py
+```
+
+This loads the production rotation script and select callback, and the production
+recovery worker list. ESPHome runs the real actions, scripts and scheduler;
+only the display/controller endpoints are replaced. It checks self-stop,
+cancellation of 22 pending workers, rapid rotation changes, all four rotation
+options and reentrant developer-mode clamping. It uses no device or Wi-Fi
+credentials. Physical rendering, touch alignment and live HTTP callbacks still
+need device testing.
+
 ### Full Firmware Compile
 
 Pull requests run the normal validation gate automatically. Full ESPHome

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:helpers": "g++ -std=c++17 -I. -Itests/stubs tests/espframe_helper_tests.cpp -o /tmp/espframe_helper_tests && /tmp/espframe_helper_tests",
     "test:parsers": "python3 scripts/test_immich_parsers.py",
     "test:identity": "g++ -std=c++17 -Itests/identity_stubs -I. tests/frame_identity_tests.cpp components/espframe/frame_identity.cpp -o /tmp/espframe_identity_tests && /tmp/espframe_identity_tests",
-    "test:firmware-logic": "npm run test:identity && npm run test:helpers && npm run test:parsers && npm run test:timezones",
+    "test:firmware-logic": "npm run test:identity && npm run test:helpers && npm run test:parsers && npm run test:timezones && npm run test:automation-controller",
     "check:fast": "npm run check:schema && npm run check:generated && npm run check:product && npm run check:backup && npm run check:compat && npm run check:ownership && npm run check:budgets && npm run check:firmware-fields",
     "check:pr": "npm run check:fast && npm run webserver:typecheck && npm run test:web-saves && npm run test:web-types && npm run test:web-compat && npm run test:web-modules && npm run test:web-smoke-cli && npm run test:web-smoke && npm run test:package-contract && npm run test:product-contract-common && npm run test:release-ready && npm run test:workflow-contract && npm run test:budgets && npm run test:ownership && npm run test:firmware-logic && npm run docs:build",
     "check:release": "npm run check:pr && npm run check:firmware-release && npm run check:release-changelog",
@@ -43,7 +43,8 @@
     "webserver:typecheck": "python3 scripts/check_web_types.py && tsc --noEmit --strict --target ES2018 --lib ES2018,DOM --skipLibCheck docs/webserver/src/web_contracts.ts docs/webserver/src/setting_save.ts",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "test:automation-controller": "g++ -std=c++17 -I. -Itests/stubs tests/automation_controller_tests.cpp -o /tmp/espframe_automation_tests && /tmp/espframe_automation_tests"
   },
   "devDependencies": {
     "ajv": "^8.20.0",

--- a/scripts/product_contract/screen_features.py
+++ b/scripts/product_contract/screen_features.py
@@ -181,7 +181,10 @@ def check_screen_rotation_metadata(product: dict, errors: list[str]) -> None:
         'initial_option: "${screen_rotation}"',
         "screen_apply_rotation",
         "developer_features_enabled",
-        "lvgl.display.set_rotation",
+        "id(espframe_core).apply_screen_rotation(",
+        "id(frame_lvgl)",
+        "mode: restart",
+        "delay: 100ms",
         "portrait_pairing_enabled",
         "immich_reapply_current_image_layout",
     ):

--- a/tests/automation_controller_tests.cpp
+++ b/tests/automation_controller_tests.cpp
@@ -1,0 +1,116 @@
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+#include "components/espframe/automation_controller.h"
+#include "components/espframe/slideshow_component.h"
+
+using namespace esphome::espframe;
+
+static void test_recovery_stop_order() {
+  std::vector<int> calls;
+  struct Worker {
+    int index;
+    std::vector<int> &calls;
+    bool running = true;
+    void stop() { calls.push_back(index); running = false; }
+  };
+  Worker first{1, calls}, second{2, calls}, third{3, calls};
+  stop_scripts_in_order(&first, &second, &third);
+  assert((calls == std::vector<int>{1, 2, 3}));
+  assert(!first.running && !second.running && !third.running);
+  // Recovery is also safe after workers have already stopped.
+  stop_scripts_in_order(&first, &second, &third);
+  assert((calls == std::vector<int>{1, 2, 3, 1, 2, 3}));
+}
+
+static void test_rotation() {
+  std::vector<int> calls;
+  struct Display {
+    std::vector<int> &calls;
+    void set_rotation(int rotation) { calls.push_back(rotation); }
+  } display{calls};
+  struct Pairing {
+    std::vector<int> &calls;
+    void turn_on() { calls.push_back(1); }
+    void turn_off() { calls.push_back(-1); }
+  } pairing{calls};
+  const std::array<std::string, 4> options{"0", "90", "180", "270"};
+  // Both current panels use the offset mapping; the helper must also preserve
+  // board substitutions when another panel supplies a different mapping.
+  for (const auto &mapping : {std::array<int, 4>{90, 180, 270, 0}, std::array<int, 4>{0, 90, 180, 270}}) {
+    for (size_t i = 0; i < options.size(); ++i) {
+      calls.clear();
+      apply_rotation_plan(rotation_plan(options[i], mapping), &display, &pairing);
+      assert((calls == std::vector<int>{mapping[i], i % 2 == 0 ? 1 : -1}));
+    }
+    for (const std::string invalid : {"", "45", "360", "invalid"}) {
+      calls.clear();
+      apply_rotation_plan(rotation_plan(invalid, mapping), &display, &pairing);
+      assert(calls.empty());
+    }
+  }
+}
+
+static void test_slot_fetch_guards() {
+  size_t cases = 0;
+  for (int active = 0; active < 3; ++active) {
+    for (int target = 0; target < 3; ++target) {
+      for (int busy = 0; busy < 8; ++busy) {
+        for (int inputs = 0; inputs < 64; ++inputs) {
+          SlideshowRuntimeState state;
+          state.active_slot = active;
+          state.target_slot = target;
+          for (int slot = 0; slot < 3; ++slot) state.slot_flags.fetch_in_flight[slot] = (busy & (1 << slot)) != 0;
+          const bool wifi = inputs & 1, configured = inputs & 2, paused = inputs & 4;
+          const bool cooldown = inputs & 8, image_busy = inputs & 16;
+          state.portrait.workflow_busy = inputs & 32;
+          // Ordered predicates from the previous YAML. First matching guard wins,
+          // including cases where several independent reasons block a request.
+          const std::array<bool, 8> blocked{
+            !wifi, !configured, paused, cooldown,
+            target != active && state.portrait.workflow_busy,
+            busy != 0 && (busy & (1 << target)) == 0,
+            (busy & (1 << target)) != 0, image_busy,
+          };
+          const std::array<SlotFetchDecision, 8> reasons{
+            SlotFetchDecision::WIFI_DISCONNECTED, SlotFetchDecision::MISSING_CONFIG,
+            SlotFetchDecision::PAUSED, SlotFetchDecision::COOLDOWN,
+            SlotFetchDecision::PORTRAIT_BUSY, SlotFetchDecision::ANOTHER_FETCH_BUSY,
+            SlotFetchDecision::SLOT_BUSY, SlotFetchDecision::IMAGE_BUSY,
+          };
+          auto expected = SlotFetchDecision::ALLOW;
+          bool deferred = false;
+          for (size_t i = 0; i < blocked.size(); ++i) {
+            if (!blocked[i]) continue;
+            expected = reasons[i];
+            deferred = i == 4 || i == 5 || i == 7;
+            break;
+          }
+          const auto actual = slot_fetch_decision(state, wifi, configured, paused, cooldown, image_busy);
+          assert(actual == expected);
+          assert(slot_fetch_needs_defer(actual) == deferred);
+          assert(state.active_slot == active && state.target_slot == target);
+          for (int slot = 0; slot < 3; ++slot)
+            assert(state.slot_flags.fetch_in_flight[slot] == ((busy & (1 << slot)) != 0));
+          ++cases;
+        }
+      }
+    }
+  }
+  for (int invalid : {-1, 3, 127}) {
+    SlideshowRuntimeState state;
+    state.target_slot = invalid;
+    assert(slot_fetch_decision(state, true, true, false, false, false) == SlotFetchDecision::INVALID_SLOT);
+    assert(slot_fetch_decision(state, false, true, false, false, false) == SlotFetchDecision::WIFI_DISCONNECTED);
+    assert(!slot_fetch_needs_defer(SlotFetchDecision::INVALID_SLOT));
+  }
+  std::cout << "Checked " << cases << " valid-slot guard combinations\n";
+}
+
+int main() {
+  test_recovery_stop_order();
+  test_rotation();
+  test_slot_fetch_guards();
+  std::cout << "Automation controller tests passed\n";
+}

--- a/tests/automation_runtime_fixture.h
+++ b/tests/automation_runtime_fixture.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "../components/espframe/automation_controller.h"
+#include <cstdio>
+#include <cstdlib>
+
+// Only the hardware endpoints are replaced. Rotation actions and select callbacks
+// come from production YAML; scripts, switches and delays use ESPHome's runtime.
+struct AutomationTestDisplay {
+  int rotation = -1;
+  void set_rotation(int value) { rotation = value; }
+};
+struct AutomationTestCore {
+  template<typename Display, typename Pairing>
+  void apply_screen_rotation(const std::string &option, const std::array<int, 4> &rotations,
+                             Display *display, Pairing *pairing) {
+    esphome::espframe::apply_rotation_plan(esphome::espframe::rotation_plan(option, rotations), display, pairing);
+  }
+};
+struct AutomationTestState {
+  int target_slot = 0, active_slot = 0;
+  struct { bool workflow_busy = false; } portrait;
+  struct { bool fetch_in_flight[3]{}; } slot_flags;
+};
+inline void automation_require(bool passed, const char *message) {
+  if (passed) return;
+  std::fprintf(stderr, "Automation runtime FAIL: %s\n", message);
+  std::exit(1);
+}

--- a/tests/automation_runtime_tests.py
+++ b/tests/automation_runtime_tests.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Run in the pinned ESPHome Docker image; no Wi-Fi secrets or device required.
+
+Loads production rotation actions and recovery worker IDs into ESPHome's host
+platform. Only hardware endpoints are faked, so cancellation/reentrancy runs
+through the real Script, Select, Switch, Action and Scheduler implementations.
+"""
+from pathlib import Path
+import re
+import subprocess
+import sys
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+CACHE = ROOT / '.esphome' / 'automation-runtime'
+
+
+def main():
+    rotation = yaml.safe_load((ROOT / 'common/addon/screen_rotation.yaml').read_text())
+    slideshow = (ROOT / 'common/addon/immich_slideshow.yaml').read_text()
+    recovery = slideshow.split('stop_slideshow_workers(', 1)[1].split(');', 1)[0]
+    workers = re.findall(r'id\((\w+)\)', recovery)
+    if len(workers) != 22 or len(set(workers)) != 22:
+        raise ValueError('Review the recovery fixture when its worker set changes')
+    select = rotation['select'][0]
+    select.pop('web_server')
+    select['restore_value'] = False  # Tests must not depend on host preferences.
+    globals_ = [
+        {'id': 'espframe_core', 'type': 'AutomationTestCore'},
+        {'id': 'frame_lvgl', 'type': 'AutomationTestDisplay *', 'initial_value': 'new AutomationTestDisplay()'},
+        {'id': 'test_state', 'type': 'AutomationTestState'},
+    ] + [{'id': name, 'type': 'int', 'initial_value': '0'} for name in
+         ('layout_count', 'worker_count', 'fetch_count')]
+    scripts = rotation['script'] + [
+        {'id': 'immich_reapply_current_image_layout', 'then': [{'lambda': 'id(layout_count)++;'}]},
+        {'id': 'fetch_guard', 'mode': 'single', 'then': [
+            {'lambda': '''
+              auto decision = esphome::espframe::slot_fetch_decision(id(test_state), true, true,
+                                                                   true, false, false);
+              if (decision != esphome::espframe::SlotFetchDecision::ALLOW) id(fetch_guard).stop();
+            '''},
+            {'lambda': 'id(fetch_count)++;'},
+        ]},
+    ] + [{'id': name, 'mode': 'restart', 'then': [
+        {'delay': '100ms'}, {'lambda': 'id(worker_count)++;'},
+    ]} for name in workers]
+    actions = [{'delay': '300ms'}, {'lambda': '''
+      id(fetch_guard).execute();
+      automation_require(id(fetch_count) == 0 && !id(fetch_guard).is_running(), "self-stop suppressed continuation");
+      id(developer_features_enabled).turn_on();
+      id(layout_count) = 0;
+      id(screen_rotation_select).publish_state("180");
+    '''}, {'delay': '50ms'}, {'lambda': 'id(screen_rotation_select).publish_state("0");'},
+        {'delay': '60ms'}, {'lambda': 'automation_require(id(layout_count) == 0, "restart cancelled old delay");'},
+        {'delay': '100ms'}, {'lambda': 'automation_require(id(layout_count) == 1, "one delayed layout after restart");'}]
+    for option, angle, pairing in [('90', 180, False), ('180', 270, True), ('270', 0, False), ('0', 90, True)]:
+        actions += [{'lambda': f'id(screen_rotation_select).publish_state("{option}");'}, {'delay': '150ms'},
+                    {'lambda': f'automation_require(id(frame_lvgl)->rotation == {angle} && id(portrait_pairing_enabled).state == {str(pairing).lower()}, "rotation {option} mapping/pairing");'}]
+    actions += [{'lambda': '''
+      id(developer_features_enabled).turn_off();
+      id(layout_count) = 0;
+      id(screen_rotation_select).publish_state("90");
+    '''}, {'delay': '200ms'}, {'lambda': '''
+      automation_require(id(screen_rotation_select).current_option() == "0", "developer clamp select");
+      automation_require(id(frame_lvgl)->rotation == 90 && id(portrait_pairing_enabled).state, "developer clamp display");
+      automation_require(id(layout_count) == 1, "one delayed layout after reentrant clamp");
+    '''}]
+    start = '\n'.join(f'id({worker}).execute();' for worker in workers)
+    stopped = ' && '.join(f'!id({worker}).is_running()' for worker in workers)
+    actions += [{'lambda': start + '\nesphome::espframe::stop_scripts_in_order(' + recovery + ');\n'
+                 + f'automation_require({stopped}, "all recovery workers stopped");'},
+                {'delay': '150ms'}, {'lambda': '''
+      automation_require(id(worker_count) == 0, "no late recovery continuations");
+      std::puts("Automation runtime tests passed");
+      std::exit(0);
+    '''}]
+    config = {
+        'substitutions': {'screen_rotation': '0', 'screen_rotation_0': '90', 'screen_rotation_90': '180',
+                          'screen_rotation_180': '270', 'screen_rotation_270': '0'},
+        'esphome': {'name': 'automation-runtime-test',
+                    'platformio_options': {'build_flags': [f'-include {ROOT / "tests/automation_runtime_fixture.h"}']},
+                    'on_boot': [{'priority': -200, 'then': actions}]},
+        'host': {}, 'logger': {'level': 'INFO'}, 'globals': globals_, 'select': [select],
+        'switch': [{'platform': 'template', 'id': name, 'optimistic': True} for name in
+                   ('developer_features_enabled', 'portrait_pairing_enabled')],
+        'script': scripts,
+    }
+    CACHE.mkdir(parents=True, exist_ok=True)
+    config_path = CACHE / 'runtime.yaml'
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    subprocess.run([sys.executable, '-m', 'esphome', 'compile', str(config_path)], check=True)
+    executable = CACHE / '.esphome/build/automation-runtime-test/.pioenvs/automation-runtime-test/program'
+    subprocess.run([str(executable)], check=True, timeout=15, cwd=CACHE)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What changes when merged

- Reduce permanent RAM used by slideshow automation actions while preserving entities, saved settings and device support. On both boards, factory RAM falls from **136,900 to 135,564 bytes**, and OTA RAM from **136,964 to 135,628 bytes**: **1,336 bytes saved**. OTA headroom under the unchanged 137,000-byte limit rises from 36 to 1,372 bytes.
- Consolidate the 22 recovery stop actions into an immediate, ordered controller call; share rotation application and its restartable 100 ms continuation; move the eight initial slot-fetch guards into a tested controller decision. Blocked requests still stop their script, and the same three busy conditions schedule deferred prefetch.
- All 114 template entities and 85 scripts remain. HTTP callbacks, retries, pagination and per-image deferred workers retain their existing action sequences. Invalid target slots are rejected before indexing their flags.

## Automated checks

- [x] `npm run check:pr` passed
- [x] CI checks are expected to pass
- Before the main-branch merge, all four full ESPHome 2026.8.2 firmware builds passed: factory and OTA for JC8012P4A1 and JC8012P4A1 V2. All existing firmware budgets passed, using the release test version `v0.0.0`.
- Host C++ tests passed 4,608 combinations of competing slot-fetch guards, ordered cancellation, invalid-slot bounds and rotation mappings.
- `docker run --rm -v "${PWD}:/config" --entrypoint python ghcr.io/esphome/esphome:2026.8.2 /config/tests/automation_runtime_tests.py` passed. It loads production rotation YAML and the recovery worker list into ESPHome's host platform. Real scripts/actions/scheduler verified self-stop, cancellation of 22 delayed workers, rapid rotation restart, all rotation options, and reentrant developer-mode clamping. Display/controller endpoints are test doubles.

### Validation after resolving conflicts

- Latest merge: `main` at `305e39d` into this PR in `a55e6a1`. Preserved both automation-controller and memory-diagnostics includes, plus the automation, WebP, memory-diagnostics and photo-buffer test groups.
- `npm run check:pr` passed locally on the latest merged tree.
- [Validate PR Gate](https://github.com/jtenniswood/espframe/actions/runs/34761094843) passed for the pushed merge commit.
- Both factory entry points compiled successfully with `ghcr.io/esphome/esphome:2026.8.2`, and both factory firmware budget checks passed. OTA entry points were not recompiled after this merge; the four-profile results above are from the original implementation.
- No device was flashed. Rotation/touch alignment, photo progression, and recovery during live image/HTTP activity still need device testing.

## Device testing

- [ ] Not needed for this change
- [ ] PR Validation artifact flashed to device
- [x] Needs device testing before merge

PR Validation workflow run/artifact: normal PR CI will run; full firmware compilation was performed locally with the same pinned image and release entry points.

Firmware artifact (`firmware-test-<device>`): no workflow artifact requested; local factory/OTA builds passed for both devices.

Device tested: no physical device flashed for this PR.

Result/notes: Before merge, verify display/touch alignment through rotation, normal photo progression, and recovery during live image/HTTP activity. Host integration covers action lifecycle but cannot prove physical rendering or late network callbacks.

## Notes for reviewers

- ELF placement-object accounting: recovery **404→52 bytes**, rotation **532→180**, slot-fetch script **1,484→860**. These explain 1,328 bytes; the whole-firmware report saves 1,336 bytes after linker/storage effects. Generated objects fall from 1,428 to 1,354; the controller gains no persistent state.
- Baseline RAM comes from the preceding production-build measurements. The retained V2 ELF used for object comparison is from the WebP branch, whose static RAM matches main. The original implementation was based directly on main `5442af2` and did not include the separate LVGL/WebP PRs; those changes are now inherited from main.
- This provides useful release headroom, roughly 1.3 KiB. Moving the remaining HTTP state machines is a separate, higher-risk follow-up; it is not required for this reduction.

